### PR TITLE
Removed invalid entries from messages.file

### DIFF
--- a/xpi/content/options.js
+++ b/xpi/content/options.js
@@ -5,15 +5,16 @@ if (!classicthemerestorerjso.ctr) {classicthemerestorerjso.ctr = {};};
 Components.utils.import("resource://gre/modules/AddonManager.jsm");
 Components.utils.import("resource:///modules/CustomizableUI.jsm");
 
-// make ctraddon_prefService "global" or 'getChildList' and 'getPrefType' required
-// by import/export (json) functions can not be accessed in e10s.
-var ctraddon_prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+//Import services use one service for preferences.
+Components.utils.import("resource://gre/modules/Services.jsm");
+//Query nsIPrefBranch see: Bug 1125570 | Bug 1083561
+Services.prefs.QueryInterface(Components.interfaces.nsIPrefBranch);
 
 classicthemerestorerjso.ctr = {
 
-  prefs:			Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("extensions.classicthemerestorer."),
-  fxdefaulttheme:	Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("general.skins.").getCharPref("selectedSkin") == 'classic/1.0',
-  appversion:		parseInt(Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService).getBranch("extensions.").getCharPref("lastAppVersion")),
+  prefs:			Services.prefs.getBranch("extensions.classicthemerestorer."),
+  fxdefaulttheme:	Services.prefs.getBranch("general.skins.").getCharPref("selectedSkin") == 'classic/1.0',
+  appversion:		parseInt(Services.prefs.getBranch("extensions.").getCharPref("lastAppVersion")),
   oswindows:		Components.classes["@mozilla.org/xre/app-info;1"].getService(Components.interfaces.nsIXULRuntime).OS=="WINNT",
   needsRestart: 	false,
   ctrVersioninWin:  true,
@@ -263,9 +264,7 @@ classicthemerestorerjso.ctr = {
 	function PrefListener(branch_name, callback) {
 	  // Keeping a reference to the observed preference branch or it will get
 	  // garbage collected.
-	  var prefService = Components.classes["@mozilla.org/preferences-service;1"]
-		.getService(Components.interfaces.nsIPrefService);
-	  this._branch = prefService.getBranch(branch_name);
+	  this._branch = Services.prefs.getBranch(branch_name);
 	  this._branch.QueryInterface(Components.interfaces.nsIPrefBranch2);
 	  this._callback = callback;
 	}
@@ -382,12 +381,8 @@ classicthemerestorerjso.ctr = {
 	
 	// if e10s is used show CTRs option to disable tab underlining
 	try{
-	  if (Components.classes["@mozilla.org/preferences-service;1"]
-		.getService(Components.interfaces.nsIPrefService)
-			.getBranch("browser.tabs.remote.").getBoolPref("autostart") || 
-				Components.classes["@mozilla.org/preferences-service;1"]
-				.getService(Components.interfaces.nsIPrefService)
-					.getBranch("browser.tabs.remote.autostart.").getBoolPref("1")) {
+	  if (Services.prefs.getBranch("browser.tabs.remote.").getBoolPref("autostart") || 
+				Services.prefs.getBranch("browser.tabs.remote.autostart.").getBoolPref("1")) {
 		document.getElementById('ctraddon_pw_e10stab_notd').disabled = false;
 		document.getElementById('ctraddon_pw_e10stab_notd').style.visibility = 'visible';
 	  }
@@ -454,12 +449,8 @@ classicthemerestorerjso.ctr = {
   ctrShowE10sPrefForWindowPrefs: function() {
 	try{
 	setTimeout(function(){
-	  if(Components.classes["@mozilla.org/preferences-service;1"]
-		.getService(Components.interfaces.nsIPrefService)
-		  .getBranch("app.update.").getCharPref("channel")=='nightly'
-			&& Components.classes["@mozilla.org/preferences-service;1"]
-			  .getService(Components.interfaces.nsIPrefService)
-				.getBranch("browser.preferences.").getBoolPref("inContent")==false) {
+	  if(Services.prefs.getBranch("app.update.").getCharPref("channel")=='nightly'
+			&& Services.prefs.getBranch("browser.preferences.").getBoolPref("inContent")==false) {
 		document.getElementById('ctraddon_pw_e10stabs').disabled = false;
 		document.getElementById('ctraddon_pw_e10stabs').style.visibility = 'visible';
 		document.getElementById('ctraddon_pw_e10stabsdescr').style.visibility = 'visible';
@@ -475,9 +466,7 @@ classicthemerestorerjso.ctr = {
   hideThemeInfoForTabs: function(){
 	setTimeout(function(){
 		try {
-		  if(Components.classes["@mozilla.org/preferences-service;1"]
-			.getService(Components.interfaces.nsIPrefService)
-				.getBranch("browser.devedition.theme.").getBoolPref('enabled')!=false){
+		  if(Services.prefs.getBranch("browser.devedition.theme.").getBoolPref('enabled')!=false){
 			document.getElementById('ctraddon_pw_tabforminfo').style.visibility = 'visible';
 			document.getElementById('ctraddon_pw_tabmenulist').disabled = true;
 		  } else if(classicthemerestorerjso.ctr.fxdefaulttheme) {
@@ -579,9 +568,7 @@ classicthemerestorerjso.ctr = {
  
   ctrpwAppbuttonextra: function(which,fromprefwindow) {
   
-  var tabsintitlebar = Components.classes["@mozilla.org/preferences-service;1"]
-						 .getService(Components.interfaces.nsIPrefService)
-						   .getBranch("browser.tabs.").getBoolPref("drawInTitlebar");
+  var tabsintitlebar = Services.prefs.getBranch("browser.tabs.").getBoolPref("drawInTitlebar");
   
 	if (which=="appbutton_v1" && this.fxdefaulttheme){
 	  document.getElementById('ctraddon_alt_abicons').disabled = false;
@@ -639,9 +626,7 @@ classicthemerestorerjso.ctr = {
 	  document.getElementById('ctraddon_appbclmmenus').disabled = false;
 	  
 	  if (tabsintitlebar==false && fromprefwindow==true) {
-		Components.classes["@mozilla.org/preferences-service;1"]
-		 .getService(Components.interfaces.nsIPrefService)
-		   .getBranch("browser.tabs.").setBoolPref("drawInTitlebar", true);
+		Services.prefs.getBranch("browser.tabs.").setBoolPref("drawInTitlebar", true);
 	  }
 	} else {
 	  document.getElementById('ctraddon_alt_abicons').disabled = true;
@@ -654,9 +639,7 @@ classicthemerestorerjso.ctr = {
 	  document.getElementById('ctraddon_appbclmmenus').disabled = false;
 	  
 	  if (tabsintitlebar==false && fromprefwindow==true) {
-		Components.classes["@mozilla.org/preferences-service;1"]
-		 .getService(Components.interfaces.nsIPrefService)
-		   .getBranch("browser.tabs.").setBoolPref("drawInTitlebar", true);
+		Services.prefs.getBranch("browser.tabs.").setBoolPref("drawInTitlebar", true);
 	  }
 	}
   },
@@ -701,9 +684,7 @@ classicthemerestorerjso.ctr = {
       preference.value = preference.defaultValue == null ? undefined : preference.defaultValue;
     }
 
-	var tabsintitlebar = Components.classes["@mozilla.org/preferences-service;1"]
-						  .getService(Components.interfaces.nsIPrefService)
-						    .getBranch("browser.tabs.").getBoolPref("drawInTitlebar");
+	var tabsintitlebar = Services.prefs.getBranch("browser.tabs.").getBoolPref("drawInTitlebar");
 										
 	if (this.oswindows && tabsintitlebar) {
 	  this.prefs.setCharPref("appbutton",'appbutton_v2');
@@ -1063,10 +1044,10 @@ classicthemerestorerjso.ctr = {
 	
 	function setPrefValue(pref, val){
 
-	  switch (ctraddon_prefService.getPrefType(pref)){
-		case 32:	return ctraddon_prefService.setCharPref(pref, val);	break;
-		case 64:	return ctraddon_prefService.setIntPref(pref, val);	break;
-		case 128:	return ctraddon_prefService.setBoolPref(pref, val);	break;	
+	  switch (Services.prefs.getPrefType(pref)){
+		case 32:	return Services.prefs.setCharPref(pref, val);	break;
+		case 64:	return Services.prefs.setIntPref(pref, val);	break;
+		case 128:	return Services.prefs.setBoolPref(pref, val);	break;	
 	  }
 
 	}
@@ -1132,7 +1113,7 @@ classicthemerestorerjso.ctr = {
   /* export CTR settings JSON */
   exportCTRpreferencesJSON: function() {
 
-	var preflist = ctraddon_prefService.getChildList("extensions.classicthemerestorer.");
+	var preflist = Services.prefs.getChildList("extensions.classicthemerestorer.");
 
 	let preferenceArray = {
 	  preference: [],
@@ -1148,10 +1129,10 @@ classicthemerestorerjso.ctr = {
 
 	function prefValue(pref){
 
-	  switch (ctraddon_prefService.getPrefType(pref)){
-		case 32:	return ctraddon_prefService.getCharPref(pref);	break;
-		case 64:	return ctraddon_prefService.getIntPref(pref);	break;
-		case 128:	return ctraddon_prefService.getBoolPref(pref);	break;	
+	  switch (Services.prefs.getPrefType(pref)){
+		case 32:	return Services.prefs.getCharPref(pref);	break;
+		case 64:	return Services.prefs.getIntPref(pref);	break;
+		case 128:	return Services.prefs.getBoolPref(pref);	break;	
 	  }
 
 	}

--- a/xpi/content/overlay.js
+++ b/xpi/content/overlay.js
@@ -10,6 +10,10 @@
 
 Cu.import("resource:///modules/CustomizableUI.jsm");
 Cu.import("resource://gre/modules/AddonManager.jsm");
+//Import services
+Cu.import("resource://gre/modules/Services.jsm");
+//Query nsIPrefBranch see: Bug 1125570 | Bug 1083561
+Services.prefs.QueryInterface(Components.interfaces.nsIPrefBranch);
 
 if (typeof classicthemerestorerjs == "undefined") {var classicthemerestorerjs = {};};
 if (!classicthemerestorerjs.ctr) {classicthemerestorerjs.ctr = {};};
@@ -54,11 +58,11 @@ classicthemerestorerjs.ctr = {
   
   cuiButtonssheet:		Cc["@mozilla.org/network/io-service;1"].getService(Ci.nsIIOService).newURI("data:text/css;charset=utf-8," + encodeURIComponent(''), null, null),
 
-  prefs:				Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).getBranch("extensions.classicthemerestorer."),
+  prefs:				Services.prefs.getBranch("extensions.classicthemerestorer."),
   
-  fxdefaulttheme:		Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).getBranch("general.skins.").getCharPref("selectedSkin") == 'classic/1.0',
+  fxdefaulttheme:		Services.prefs.getBranch("general.skins.").getCharPref("selectedSkin") == 'classic/1.0',
   osstring:				Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime).OS,
-  appversion:			parseInt(Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).getBranch("extensions.").getCharPref("lastAppVersion")),
+  appversion:			parseInt(Services.prefs.getBranch("extensions.").getCharPref("lastAppVersion")),
   stringBundle:			Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService).createBundle("chrome://classic_theme_restorer/locale/messages.file"),
   
   hideTTWithOneTab:		false,
@@ -78,7 +82,7 @@ classicthemerestorerjs.ctr = {
 		  document.getElementById("main-window").setAttribute('defaultfxtheme',true);
 		}
 		else {
-		  var thirdpartytheme = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).getBranch("general.skins.").getCharPref("selectedSkin");
+		  var thirdpartytheme = Services.prefs.getBranch("general.skins.").getCharPref("selectedSkin");
 		  document.getElementById("main-window").setAttribute('currenttheme',thirdpartytheme);
 		  classicthemerestorerjs.ctr.loadUnloadCSS("thirdpartythemes",true);
 		}
@@ -131,9 +135,7 @@ classicthemerestorerjs.ctr = {
 	function PrefListener(branch_name, callback) {
 	  // Keeping a reference to the observed preference branch or it will get
 	  // garbage collected.
-	  var prefService = Cc["@mozilla.org/preferences-service;1"]
-		.getService(Ci.nsIPrefService);
-	  this._branch = prefService.getBranch(branch_name);
+	  this._branch = Services.prefs.getBranch(branch_name);
 	  this._branch.QueryInterface(Ci.nsIPrefBranch2);
 	  this._callback = callback;
 	}
@@ -210,15 +212,12 @@ classicthemerestorerjs.ctr = {
 				if (classicthemerestorerjs.ctr.osstring=="WINNT") CustomizableUI.addWidgetToArea("ctraddon_window-controls", CustomizableUI.AREA_NAVBAR);
 				CustomizableUI.addWidgetToArea("ctraddon_bookmarks-menu-toolbar-button", CustomizableUI.AREA_BOOKMARKS);						
 
-				var tabsintitlebar = Cc["@mozilla.org/preferences-service;1"]
-									  .getService(Ci.nsIPrefService)
-										.getBranch("browser.tabs.").getBoolPref("drawInTitlebar");
+				var tabsintitlebar = Services.prefs.getBranch("browser.tabs.").getBoolPref("drawInTitlebar");
 										
 				// TMPs/TUs colors for rounded tabs in Fx29+ are not compatible with CTRs (squared) tabs.
 				// This just disables TMPs/TUs non-compatible tab color options on first run (once).
 				try{
-				  var tmpprefs = Cc["@mozilla.org/preferences-service;1"]
-									.getService(Ci.nsIPrefService).getBranch("extensions.tabmix.");
+				  var tmpprefs = Services.prefs.getBranch("extensions.tabmix.");
 				  if(tmpprefs.getBoolPref("currentTab")) tmpprefs.setBoolPref("currentTab",false);
 				  if(tmpprefs.getBoolPref("unloadedTab")) tmpprefs.setBoolPref("unloadedTab",false);
 				  if(tmpprefs.getBoolPref("unreadTab")) tmpprefs.setBoolPref("unreadTab",false);
@@ -226,8 +225,7 @@ classicthemerestorerjs.ctr = {
 				} catch(e){}
 
 				try{
-				  var tuprefs = Cc["@mozilla.org/preferences-service;1"]
-									.getService(Ci.nsIPrefService).getBranch("extensions.tabutils.");
+				  var tuprefs = Services.prefs.getBranch("extensions.tabutils.");
 				  if(tuprefs.getBoolPref("highlightCurrent")) tuprefs.setBoolPref("highlightCurrent",false);
 				  if(tuprefs.getBoolPref("highlightRead")) tuprefs.setBoolPref("highlightRead",false);
 				  if(tuprefs.getBoolPref("highlightSelected")) tuprefs.setBoolPref("highlightSelected",false);
@@ -275,7 +273,7 @@ classicthemerestorerjs.ctr = {
 			var devtheme=false;
 
 			try {
-			  if(Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).getBranch("browser.devedition.theme.").getBoolPref('enabled')!=false){
+			  if(Services.prefs.getBranch("browser.devedition.theme.").getBoolPref('enabled')!=false){
 				devtheme=true;
 			  }
 			} catch(e) {}
@@ -362,24 +360,20 @@ classicthemerestorerjs.ctr = {
 		  
 		  case "closetab":
 		  
-			var def_tcw = Cc["@mozilla.org/preferences-service;1"]
-						  .getService(Ci.nsIPrefService)
-							.getBranch("browser.tabs.").getIntPref("tabClipWidth") == 140;
+			var def_tcw = Services.prefs.getBranch("browser.tabs.").getIntPref("tabClipWidth") == 140;
 
 			classicthemerestorerjs.ctr.loadUnloadCSS('closetab_active',false);
 			classicthemerestorerjs.ctr.loadUnloadCSS('closetab_none',false);
 			classicthemerestorerjs.ctr.loadUnloadCSS('closetab_tb_end',false);
 			classicthemerestorerjs.ctr.loadUnloadCSS('closetab_tb_start',false);
 			if (def_tcw==false) {
-			  Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService)
-				.getBranch("browser.tabs.").setIntPref("tabClipWidth",140);
+			  Services.prefs.getBranch("browser.tabs.").setIntPref("tabClipWidth",140);
 			}
 			
 			if (branch.getCharPref("closetab")!="closetab_default"){
 			  
 			  if (branch.getCharPref("closetab")=="closetab_forced") {
-				Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService)
-				  .getBranch("browser.tabs.").setIntPref("tabClipWidth",1);
+				Services.prefs.getBranch("browser.tabs.").setIntPref("tabClipWidth",1);
 			  }
 			  else if (classicthemerestorerjs.ctr.appversion >= 31) {
 			    classicthemerestorerjs.ctr.loadUnloadCSS(branch.getCharPref("closetab"),true);
@@ -469,7 +463,7 @@ classicthemerestorerjs.ctr = {
 			var devtheme=false;
 
 			try {
-			  if(Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).getBranch("browser.devedition.theme.").getBoolPref('enabled')!=false){
+			  if(Services.prefs.getBranch("browser.devedition.theme.").getBoolPref('enabled')!=false){
 				devtheme=true;
 			  }
 			} catch(e) {}
@@ -520,8 +514,7 @@ classicthemerestorerjs.ctr = {
 			var cstbb = false;
 			//if CTB add-on is installed and navbarbuttons option is not off
 			try {
-			  if(Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService)
-				  .getBranch("extensions.cstbb-extension.").getCharPref("navbarbuttons")!="nabbuttons_off")
+			  if(Services.prefs.getBranch("extensions.cstbb-extension.").getCharPref("navbarbuttons")!="nabbuttons_off")
 			   cstbb = true;
 			} catch(e){}
 	
@@ -1542,10 +1535,8 @@ classicthemerestorerjs.ctr = {
 		  case "nodevtheme":
 			if (branch.getBoolPref("nodevtheme")) {
 			  	try{
-					if(Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService)
-						.getBranch("browser.devedition.theme.").getBoolPref("enabled"))
-					  Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService)
-						.getBranch("browser.devedition.theme.").setBoolPref("enabled",false)
+					if(Services.prefs.getBranch("browser.devedition.theme.").getBoolPref("enabled"))
+					  Services.prefs.getBranch("browser.devedition.theme.").setBoolPref("enabled",false)
 				} catch(e){}
 			}
 		  break;
@@ -1610,7 +1601,7 @@ classicthemerestorerjs.ctr = {
 		} else if(this.fxdefaulttheme==true){
 			var devthemeosx=false;
 			try {
-			  if(Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService).getBranch("browser.devedition.theme.").getBoolPref('enabled')!=false){
+			  if(Services.prefs.getBranch("browser.devedition.theme.").getBoolPref('enabled')!=false){
 			    devthemeosx=true;
 			  }
 			} catch(e) {}
@@ -1850,8 +1841,7 @@ classicthemerestorerjs.ctr = {
 	
 	var cstbb = false;
 	try {
-	  if(Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService)
-		  .getBranch("extensions.cstbb-extension.").getCharPref("navbarbuttons")!="nabbuttons_off")
+	  if(Services.prefs.getBranch("extensions.cstbb-extension.").getCharPref("navbarbuttons")!="nabbuttons_off")
 	   cstbb = true;
 	} catch(e){}
 
@@ -1885,8 +1875,7 @@ classicthemerestorerjs.ctr = {
 
 	function ctrTabClose(event){
 	
-	  var tabsintitlebar = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService)
-							.getBranch("browser.tabs.").getBoolPref("drawInTitlebar");
+	  var tabsintitlebar = Services.prefs.getBranch("browser.tabs.").getBoolPref("drawInTitlebar");
 					  
 	  if(gBrowser.tabContainer.tabbrowser.visibleTabs.length < 2) {
 		

--- a/xpi/locale/tr/messages.file
+++ b/xpi/locale/tr/messages.file
@@ -1,10 +1,5 @@
 popup.title=Klasik Arayüz Getirici
 popup.msg.restart=Değişikliklerin geçerli olması için Cyberfox yeniden başlatılmalı.\nYeniden başlatılsın mı?
 import.error=ERROR: Yanlış ve ya değiştirilmiş bir dosya bulundu!\nHiçbirşey aktarılamadı!
-import.errorJSON=Were sorry but something has gone wrong while trying to import CTRpreferences.json (json is not valid!)
 ctr_extrabar=Additional Toolbar
 ctr_actthrobber=Activity Indicator
-notification_msg_firstrun=CTRpreferences has been found select restart to apply
-notification_button_firstrun=Restart
-notification_msg_change=Your pre-set CTRpreferences has been modified 
-notification_button_change=Options


### PR DESCRIPTION
These entries are not related to classic theme restorer as the function\feature is not present, To prevent confusion these entries have been removed to make messages.file the same as the other messages.file's.