### PR TITLE
Dynamically add the browser name to message.file

### DIFF
--- a/xpi/content/css/personanoshadow.css
+++ b/xpi/content/css/personanoshadow.css
@@ -1,0 +1,9 @@
+@namespace url(http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul);
+
+@-moz-document url(chrome://browser/content/browser.xul) {
+  #main-window #toolbar-menubar,
+  #main-window #PersonalToolbar,
+  #main-window #navigator-toolbox #TabsToolbar .tabbrowser-tab .tab-text{
+    text-shadow:none!important;
+  }
+}

--- a/xpi/content/options.js
+++ b/xpi/content/options.js
@@ -402,11 +402,12 @@ classicthemerestorerjso.ctr = {
 	var promptSvc  	 = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
 	var stringBundle = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService)
 						.createBundle("chrome://classic_theme_restorer/locale/messages.file");
+	var brandName = Services.strings.createBundle("chrome://branding/locale/brand.properties").GetStringFromName("brandShortName")					
 
 	if (this.needsRestart &&
 		promptSvc.confirm(null,
 			stringBundle.GetStringFromName("popup.title"),
-			stringBundle.GetStringFromName("popup.msg.restart")
+			stringBundle.formatStringFromName("popup.msg.restart", [brandName], 1)
 		)) {
 		observerSvc.notifyObservers(cancelQuit, "quit-application-requested", "restart");
 		if(cancelQuit.data) { // The quit request has been cancelled.

--- a/xpi/content/options.xul
+++ b/xpi/content/options.xul
@@ -223,7 +223,7 @@
 		<preference id="ctraddon_puictrbutton"	name="extensions.classicthemerestorer.puictrbutton"	type="bool"		instantApply="true"/>
 		<preference id="ctraddon_cuibuttons"	name="extensions.classicthemerestorer.cuibuttons"	type="bool"		instantApply="true"/>
 		<preference id="ctraddon_bmarkoinpw"	name="extensions.classicthemerestorer.bmarkoinpw"	type="bool"		instantApply="true"/>
-
+	<preference id="ctraddon_personanoshadowp"	name="extensions.classicthemerestorer.personanoshadow"	type="bool"		instantApply="true"/>
 	</preferences>
 
 
@@ -288,7 +288,7 @@
 		<checkbox label="&Ctr_noemptypticon;"	preference="ctraddon_noemptypticon" id="ctraddon_pw_tab_noemptypticon"/>
 		<checkbox label="&Ctr_throbberalt;"		preference="ctraddon_throbberalt" id="ctraddon_pw_throbberalt"/>
 		<checkbox label="&Ctr_e10stab_notd;" 	preference="ctraddon_e10stab_notd" id="ctraddon_pw_e10stab_notd"/>
-		
+		<checkbox label="&ctr_personanoshadow;"	preference="ctraddon_personanoshadowp" id="ctraddon_personanoshadowpt"/>		
 		<hbox>
 		  <checkbox label="&Ctr_tabminheight;"	preference="ctraddon_ctabheightcb" id="ctraddon_pw_tab_ctabheightcb"/>
 		  <textbox size="2" maxlength="2" preference="ctraddon_ctabheight" type="number" min="18" max="50" id="ctraddon_pw_tab_ctabheight"/>

--- a/xpi/content/overlay.js
+++ b/xpi/content/overlay.js
@@ -341,6 +341,16 @@ classicthemerestorerjs.ctr = {
 			classicthemerestorerjs.ctr.loadUnloadCSS('cui_buttons',true);
 			
 		  break;
+
+		  case "personanoshadow":
+			try {
+					if (branch.getBoolPref("personanoshadow")){
+							classicthemerestorerjs.ctr.loadUnloadCSS("persona_no_shadow",true);
+					} else {
+						classicthemerestorerjs.ctr.loadUnloadCSS("persona_no_shadow",false);
+					}	
+				} catch(e){}		  
+		  break;
 		  
 		  case "ctabheightcb":
 			if (branch.getBoolPref("ctabheightcb")) classicthemerestorerjs.ctr.loadUnloadCSS("ctabheight",true);
@@ -2542,6 +2552,7 @@ classicthemerestorerjs.ctr = {
 		case "bmarkoinpw":			manageCSS("ctraddon_bmark_oinpw.css");	break;
 		
 		case "spaces_extra": 		manageCSS("spaces_extra.css");			break;
+		case "persona_no_shadow": 		manageCSS("personanoshadow.css");	break;
 		
 		case "thirdpartythemes": 	manageCSS("thirdpartythemes.css");		break;
 		

--- a/xpi/content/overlay.xul
+++ b/xpi/content/overlay.xul
@@ -156,14 +156,14 @@
 	<!--### CTR entry in menubars 'Tools' menu popup ###-->
 	<menupopup id="menu_ToolsPopup">
 	  <menuitem oncommand="classicthemerestorerjs.ctr.openCTRPreferences();"
-		label="Classic Theme Restorer"
+		label="&Ctr_title;"
 		class="menuitem-iconic"
 		id="ctraddon_tools_menu_entry"/>
 	</menupopup>
 	
 	<menupopup id="toolbar-context-menu">
 	  <menuitem oncommand="classicthemerestorerjs.ctr.openCTRPreferences();"
-		label="Classic Theme Restorer"
+		label="&Ctr_title;"
 		class="menuitem-iconic"
 		id="ctraddon_context_menu_entry"/>
 	</menupopup>
@@ -569,7 +569,7 @@
 							label="&viewCustomizeToolbar.label;"/>
 				  <menuseparator id="ctraddon_appmenu_sep" collapsed="true"/>
 				  <menuitem oncommand="classicthemerestorerjs.ctr.openCTRPreferences();"
-							label="Classic Theme Restorer"
+							label="&Ctr_title;"
 							class="menuitem-iconic"
 							id="ctraddon_appmenu_ctr"/>
 			  </menupopup>
@@ -596,7 +596,7 @@
 							label="&viewCustomizeToolbar.label;"/>
 				  <menuseparator id="ctraddon_appmenu_sep2" collapsed="true"/>
 				  <menuitem oncommand="classicthemerestorerjs.ctr.openCTRPreferences();"
-							label="Classic Theme Restorer"
+							label="&Ctr_title;"
 							class="menuitem-iconic"
 							id="ctraddon_appmenu_ctr2"/>
 			  </menupopup>
@@ -674,7 +674,7 @@
                      persist="class"
                      removable="true"
                      type="menu"
-                     label="Firefox"
+                     label="&brandShortName;"
 					 popup="appmenu-popup"
 					 onmousedown="classicthemerestorerjs.ctr.openCtrAppmenuPopup();">
 	  </toolbarbutton>
@@ -810,7 +810,7 @@
 					 persist="class"
 					 cui-areatype="toolbar"
 					 oncommand="classicthemerestorerjs.ctr.openCTRPreferences();"
-                     tooltiptext="Classic Theme Restorer"/>
+                     tooltiptext="&Ctr_title;"/>
 
 	  <!--### creates a bookmarks sidebar button ###-->
 	  <toolbarbutton id="ctraddon_bookmarks-button" class="toolbarbutton-1 chromeclass-toolbar-additional ctraddon-toolbarbutton"

--- a/xpi/defaults/preferences/options.js
+++ b/xpi/defaults/preferences/options.js
@@ -203,3 +203,6 @@ pref("extensions.classicthemerestorer.tabc_hov_unl",false);
 
 // first run/reset preference
 pref("extensions.classicthemerestorer.ctrreset",true);
+
+//No text shadow on persona themes.
+pref("extensions.classicthemerestorer.personanoshadow", false);

--- a/xpi/locale/cs/messages.file
+++ b/xpi/locale/cs/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Pro dokončení změn nastavení musí být Firefox restartován.\nChcete ho nyní restartovat?
+popup.msg.restart=Pro dokončení změn nastavení musí být %S restartován.\nChcete ho nyní restartovat?
 import.error=CHYBA: Nalezen špatný nebo upravený soubor!\nImport nelze provést!
 ctr_extrabar=Přídavná lišta
 ctr_actthrobber=Activity Indicator

--- a/xpi/locale/cs/options.dtd
+++ b/xpi/locale/cs/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/da/messages.file
+++ b/xpi/locale/da/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox skal genstartes før ændringerne kan træde i kraft.\nVil du genstarte nu?
+popup.msg.restart=%S skal genstartes før ændringerne kan træde i kraft.\nVil du genstarte nu?
 import.error=FEJL: Fandt forkert eller ændret fil!\nIntet kunne importeres!
 ctr_extrabar=Yderligere værktøjslinje
 ctr_actthrobber=Aktivitetsindikator

--- a/xpi/locale/da/options.dtd
+++ b/xpi/locale/da/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/de/messages.file
+++ b/xpi/locale/de/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Änderungen werden erst nach einem Neustart übernommen.\nSoll Firefox jetzt neugestartet werden?
+popup.msg.restart=Änderungen werden erst nach einem Neustart übernommen.\nSoll %S jetzt neugestartet werden?
 import.error=FEHLER: Falsche oder modifizierte Datei gefunden!\nEs konnte nichts importiert werden!
 ctr_extrabar=Extraleiste
 ctr_actthrobber=Aktivitätsanzeige

--- a/xpi/locale/de/options.dtd
+++ b/xpi/locale/de/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/dsb/messages.file
+++ b/xpi/locale/dsb/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox musy se znowego startowaś, aby se změny wustatkowali.\nNěnto znowego startowaś?
+popup.msg.restart=%S musy se znowego startowaś, aby se změny wustatkowali.\nNěnto znowego startowaś?
 import.error=ZMÓLKA: Wopacna abo změnjona dataja jo se namakała!\nJo móžno, až se nic njeimportěrujo!
 ctr_extrabar=Pśidatna symbolowa rědka
 ctr_actthrobber=Pokazka aktiwity

--- a/xpi/locale/dsb/options.dtd
+++ b/xpi/locale/dsb/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/el/messages.file
+++ b/xpi/locale/el/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Επαναφορέας κλασικού θέματος
-popup.msg.restart=Ο Firefox θα πρέπει να επανεκκινηθεί για να εφαρμοστούν οι αλλαγές.\nΕπανεκκίνηση τώρα;
+popup.msg.restart=Ο %S θα πρέπει να επανεκκινηθεί για να εφαρμοστούν οι αλλαγές.\nΕπανεκκίνηση τώρα;
 import.error=ΣΦΑΛΜΑ: Βρέθηκε λάθος ή τροποποιημένο αρχείο!\nΤίποτα δεν κατέστη δυνατό να εισαχθεί!
 ctr_extrabar=Επιπρόσθετη εργαλειοθήκη
 ctr_actthrobber=Ενδείκτης δραστηριότητας

--- a/xpi/locale/el/options.dtd
+++ b/xpi/locale/el/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/en-US/messages.file
+++ b/xpi/locale/en-US/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox has to be restarted for changes to take effect.\nRestart now?
+popup.msg.restart=%S has to be restarted for changes to take effect.\nRestart now?
 import.error=ERROR: Found wrong or modified file!\nNothing could be imported!
 ctr_extrabar=Additional Toolbar
 ctr_actthrobber=Activity Indicator

--- a/xpi/locale/en-US/options.dtd
+++ b/xpi/locale/en-US/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/es/messages.file
+++ b/xpi/locale/es/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox ha de ser reiniciado para que se efectúen los cambios.\n¿Reiniciar ahora?
+popup.msg.restart=%S ha de ser reiniciado para que se efectúen los cambios.\n¿Reiniciar ahora?
 import.error=ERROR: ¡Se encontró un fichero erróneo o modificado!\n¡No se pudo importar nada!
 ctr_extrabar=Barra de herramientas adicional
 ctr_actthrobber=Indicador de actividad (throbber)

--- a/xpi/locale/es/options.dtd
+++ b/xpi/locale/es/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/fr/messages.file
+++ b/xpi/locale/fr/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox doit être redémarré pour que les changements de configuration soient pris en compte.\nEst-ce que cela doit être fait maintenant?
+popup.msg.restart=%S doit être redémarré pour que les changements de configuration soient pris en compte.\nEst-ce que cela doit être fait maintenant?
 import.error=ERROR: Fichier erroné ou modifié!\nRien ne peut être importé!
 ctr_extrabar=Barre d'outils supplémentaire
 ctr_actthrobber=Indicateur d'activité

--- a/xpi/locale/fr/options.dtd
+++ b/xpi/locale/fr/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Enlever les ombres au texte des thèmes Persona.">

--- a/xpi/locale/hsb/messages.file
+++ b/xpi/locale/hsb/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox dyrbi so znowa startować, zo bychu so změny wuskutkowali.\nNětko znowa startować?
+popup.msg.restart=%S dyrbi so znowa startować, zo bychu so změny wuskutkowali.\nNětko znowa startować?
 import.error=ZMYLK: Wopačna abo změnjena dataja je so namakała!\nJe móžno, zo so ničo njeimportuje!
 ctr_extrabar=Přidatna symbolowa lajsta
 ctr_actthrobber=Wozjewjenje aktiwity

--- a/xpi/locale/hsb/options.dtd
+++ b/xpi/locale/hsb/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/it/messages.file
+++ b/xpi/locale/it/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=È necessario riavviare Firefox per rendere effettive le modifiche.\nRiavviare adesso?
+popup.msg.restart=È necessario riavviare %S per rendere effettive le modifiche.\nRiavviare adesso?
 import.error=Errore: rilevato file corrotto o modificato.\nNon è possibile importare alcun dato.
 ctr_extrabar=Barra degli strumenti aggiuntiva
 ctr_actthrobber=Indicatore di attività

--- a/xpi/locale/it/options.dtd
+++ b/xpi/locale/it/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/ja/messages.file
+++ b/xpi/locale/ja/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=変更を有効にするためにはFirefoxを再起動する必要があります。\今すぐ再起動しますか？
+popup.msg.restart=変更を有効にするためには%Sを再起動する必要があります。\今すぐ再起動しますか？
 import.error=エラー：誤りが見つかったかファイルが修正されています。\nインポートされませんでした。
 ctr_extrabar=追加のツールバー
 ctr_actthrobber=Activity Indicator

--- a/xpi/locale/ja/options.dtd
+++ b/xpi/locale/ja/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/pl/messages.file
+++ b/xpi/locale/pl/messages.file
@@ -1,5 +1,7 @@
-﻿popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox musi zostać zerestartowany, aby zmiany przyniosły efekt.\nZrestartować teraz?
+﻿# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
+popup.title=Classic Theme Restorer
+popup.msg.restart=%S musi zostać zerestartowany, aby zmiany przyniosły efekt.\nZrestartować teraz?
 import.error=BŁĄD: Znaleziono błędny albo zmodyfikowany plik!\nNic nie zostało zaimportowane!
 ctr_extrabar=Dodatkowy pasek narzędzi
 ctr_actthrobber=Wskaźnik aktywności

--- a/xpi/locale/pl/options.dtd
+++ b/xpi/locale/pl/options.dtd
@@ -274,3 +274,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/pt-BR/messages.file
+++ b/xpi/locale/pt-BR/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=O Firefox Deve ser Reiniciado para Aplicar as Alterações.\nDeseja Reiniciá-lo Agora?
+popup.msg.restart=O %S Deve ser Reiniciado para Aplicar as Alterações.\nDeseja Reiniciá-lo Agora?
 import.error=ERRO: O Arquivo Encontrado Está Errado ou Foi Alterado!\nNada Pode Ser Importado!
 ctr_extrabar=Barra de Ferramentas Adicional
 ctr_actthrobber=Indicador de Atividade

--- a/xpi/locale/pt-BR/options.dtd
+++ b/xpi/locale/pt-BR/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/ru/messages.file
+++ b/xpi/locale/ru/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox должен быть перезапущен для вступления изменений в силу. \nВы хотите сделать это сейчас?
+popup.msg.restart=%S должен быть перезапущен для вступления изменений в силу. \nВы хотите сделать это сейчас?
 import.error=ОШИБКА: Найден неправильный или изменённый файл\nНичего не может быть импортировано!
 ctr_extrabar=Дополнительная панель
 ctr_actthrobber=Индикатор активности

--- a/xpi/locale/ru/options.dtd
+++ b/xpi/locale/ru/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/sl/messages.file
+++ b/xpi/locale/sl/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Za uveljavitev sprememb se mora Firefox ponovno zagnati.\nPonovno zaženi zdaj?
+popup.msg.restart=Za uveljavitev sprememb se mora %S ponovno zagnati.\nPonovno zaženi zdaj?
 import.error=NAPAKA: Najdena je bila napačna ali spremenjena datoteka!\nNičesar ni bilo mogoče uvoziti!
 ctr_extrabar=Dodatna orodna vrstica
 ctr_actthrobber=Kazalec dejavnosti

--- a/xpi/locale/sl/options.dtd
+++ b/xpi/locale/sl/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/tr/messages.file
+++ b/xpi/locale/tr/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Klasik Arayüz Getirici
-popup.msg.restart=Değişikliklerin geçerli olması için Firefox yeniden başlatılmalı.\nYeniden başlatılsın mı?
+popup.msg.restart=Değişikliklerin geçerli olması için %S yeniden başlatılmalı.\nYeniden başlatılsın mı?
 import.error=ERROR: Yanlış ve ya değiştirilmiş bir dosya bulundu!\nHiçbirşey aktarılamadı!
 ctr_extrabar=Ek Araç Çubuğu
 ctr_actthrobber=Etkinlik Göstergesi

--- a/xpi/locale/tr/options.dtd
+++ b/xpi/locale/tr/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/uk/messages.file
+++ b/xpi/locale/uk/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox треба перезапустити, щоб задіяти зміни.\nПерезапустити зараз?
+popup.msg.restart=%S треба перезапустити, щоб задіяти зміни.\nПерезапустити зараз?
 import.error=ПОМИЛКА: Знайдено неправильний або модифікований файл!\nНічого не може бути імпортовано!
 ctr_extrabar=Додаткова панель
 ctr_actthrobber=Індикатор активності

--- a/xpi/locale/uk/options.dtd
+++ b/xpi/locale/uk/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/zh-CN/messages.file
+++ b/xpi/locale/zh-CN/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox 需要重启才能生效。\n现在就重启吗?
+popup.msg.restart=%S 需要重启才能生效。\n现在就重启吗?
 import.error=错误：发现修改的或者是错误的文件。\n无法被导入！
 ctr_extrabar=附加工具栏
 ctr_actthrobber=活动指示器

--- a/xpi/locale/zh-CN/options.dtd
+++ b/xpi/locale/zh-CN/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">

--- a/xpi/locale/zh-TW/messages.file
+++ b/xpi/locale/zh-TW/messages.file
@@ -1,5 +1,7 @@
+# LOCALIZATION NOTE (popup.msg.restart):
+# %S will be replaced by brandShortName
 popup.title=Classic Theme Restorer
-popup.msg.restart=Firefox 需要重新啟動以套用新的設定值。\n現在重啟?
+popup.msg.restart=%S 需要重新啟動以套用新的設定值。\n現在重啟?
 import.error=錯誤: 發現錯誤或檔案損壞!\n匯入已中止!
 ctr_extrabar=新增工具列
 ctr_actthrobber=進度指示器

--- a/xpi/locale/zh-TW/options.dtd
+++ b/xpi/locale/zh-TW/options.dtd
@@ -273,3 +273,5 @@
 <!ENTITY openCmd.commandkey			"">
 <!ENTITY urlbar.accesskey			"">
 <!ENTITY urlbar.placeholder2		"">
+
+<!ENTITY ctr_personanoshadow	"Remove text shadow on persona themes">


### PR DESCRIPTION
This change grabs the browsers localized name from the browser
brand.properties then passes this to the restart message.

This means if there is a translated word for Firefox it will show or if
the browsers name is not the hard-coded Firefox it will display that
name.