### PR TITLE
style Slim Chrome correctly with Blue Aero Colors

### DIFF
--- a/xpi/content/overlay.js
+++ b/xpi/content/overlay.js
@@ -2742,15 +2742,21 @@ classicthemerestorerjs.ctr = {
 					@namespace url(http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul);\
 					@-moz-document url(chrome://browser/content/browser.xul) {\
 						/* Toolbars */\
-						#main-window[defaultfxtheme="true"] #nav-bar:not(:-moz-lwtheme){\
+						#main-window[defaultfxtheme="true"] :not(#theFoxOnlyBetter-slimChrome-toolbars) > #nav-bar:not(:-moz-lwtheme){\
 						  background-image: -moz-linear-gradient(#eaf2fb,#dbeaf9) !important;\
 						  box-shadow:unset !important;\
 						}\
 						#main-window[defaultfxtheme="true"][tabsontop="false"] #TabsToolbar:not(:-moz-lwtheme),\
-						#main-window[defaultfxtheme="true"] toolbar:not(#toolbar-menubar):not(#TabsToolbar):not(#nav-bar):not(.devtools-tabbar):not(#developer-toolbar):not(#puzzleBars-urlbar-bar),\
+						#main-window[defaultfxtheme="true"] :not(#theFoxOnlyBetter-slimChrome-toolbars) > toolbar:not(#toolbar-menubar):not(#TabsToolbar):not(#nav-bar):not(.devtools-tabbar):not(#developer-toolbar):not(#puzzleBars-urlbar-bar):not(#theFoxOnlyBetter-skyLights-container):not(#theFoxOnlyBetter-slimChrome-slimmer),\
+						/* The Fox, Only Better\'s Slim Chrome toolbars; apply the color to the toolbar container rather than to the toolbars themselves */\
+						#main-window[defaultfxtheme="true"] #theFoxOnlyBetter-slimChrome-container > *:not(#theFoxOnlyBetter-slimChrome-toolbars-bottom):not(:-moz-lwtheme),\
 						#main-window[defaultfxtheme="true"] #ctraddon_urlextrabar:not(:-moz-lwtheme){\
 						  background-image:unset !important;\
 						  background-color:#dbeaf9 !important;\
+						}\
+						/* The Fox, Only Better\'s Slim Chrome toolbars; the extra -slimmer[...] selector is so this only apllies when the nav-bar is also hidden automatically, no need for the gradient otherwise as it will be in the nav-bar itself */\
+						#main-window[defaultfxtheme="true"] #theFoxOnlyBetter-slimChrome-slimmer:not([collapsed]) ~ #theFoxOnlyBetter-slimChrome-container > *:not(#theFoxOnlyBetter-slimChrome-toolbars-bottom):not(:-moz-lwtheme){\
+						  background-image: -moz-linear-gradient(#eaf2fb 0px, #dbeaf9 36px, #dbeaf9) !important;\
 						}\
 						/* location bar / search bar borders */\
 						#main-window[defaultfxtheme="true"] #urlbar:not(:-moz-lwtheme),\


### PR DESCRIPTION
Hi Aris, I was told about an issue with the the "Border Aero colors in toolbars" option when used together with my add-on The Fox, Only Better (https://github.com/Quicksaver/The-Fox--Only-Better/issues/92). Basically it was the same as before with the "Remove background from toolbars" if you remember from some time ago, basically it should style the container where the toolbars are rather than the toolbars themselves (more info if you'd like: https://github.com/Quicksaver/The-Fox--Only-Better/issues/24).

This was pretty simple so I went ahead and wrote the CSS in, from my testing it seems to work great. But let me know if you need anything else or need more info in case you want to change that code to another format, or in case I screwed up of course. :)