### PR TITLE
Dynamically add browser name to localization, Utlilize imported features, Adjust restart event.

### DIFF
--- a/xpi/content/options.js
+++ b/xpi/content/options.js
@@ -15,7 +15,7 @@ classicthemerestorerjso.ctr = {
   prefs:			Services.prefs.getBranch("extensions.classicthemerestorer."),
   fxdefaulttheme:	Services.prefs.getBranch("general.skins.").getCharPref("selectedSkin") == 'classic/1.0',
   appversion:		parseInt(Services.prefs.getBranch("extensions.").getCharPref("lastAppVersion")),
-  oswindows:		Components.classes["@mozilla.org/xre/app-info;1"].getService(Components.interfaces.nsIXULRuntime).OS=="WINNT",
+  oswindows:		Services.appinfo.OS=="WINNT",
   needsRestart: 	false,
   ctrVersioninWin:  true,
   tmp_tu_active:	false,
@@ -445,12 +445,11 @@ classicthemerestorerjso.ctr = {
      when preference window gets closed */
   unloadprefwindow: function() {
 
-	var app        	 = Components.classes["@mozilla.org/toolkit/app-startup;1"].getService(Components.interfaces.nsIAppStartup);
+	var app        	 = Services.startup;
 	var cancelQuit   = Components.classes["@mozilla.org/supports-PRBool;1"].createInstance(Components.interfaces.nsISupportsPRBool);
 	var observerSvc  = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-	var promptSvc  	 = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
-	var stringBundle = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService)
-						.createBundle("chrome://classic_theme_restorer/locale/messages.file");
+	var promptSvc  	 = Services.prompt;
+	var stringBundle = Services.strings.createBundle("chrome://classic_theme_restorer/locale/messages.file");
 						
 	var brandName	 = '';
 
@@ -938,8 +937,7 @@ classicthemerestorerjso.ctr = {
   /* import CTR settings */
   importCTRpreferences: function() {
  
-	var stringBundle = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService)
-	                    .createBundle("chrome://classic_theme_restorer/locale/messages.file");
+	var stringBundle = Services.strings.createBundle("chrome://classic_theme_restorer/locale/messages.file");
   
 	var pattern = loadFromFile();
 
@@ -1011,9 +1009,7 @@ classicthemerestorerjso.ctr = {
   /* import CTR settings JSON*/
   importCTRpreferencesJSON: function() {
  
-	var stringBundle = Components.classes["@mozilla.org/intl/stringbundle;1"]
-						.getService(Components.interfaces.nsIStringBundleService)
-							.createBundle("chrome://classic_theme_restorer/locale/messages.file");
+	var stringBundle = Services.strings.createBundle("chrome://classic_theme_restorer/locale/messages.file");
 
 	var parjson = loadFromFile();
 

--- a/xpi/content/options.js
+++ b/xpi/content/options.js
@@ -445,10 +445,8 @@ classicthemerestorerjso.ctr = {
      when preference window gets closed */
   unloadprefwindow: function() {
 
-	var app        	 = Services.startup;
 	var cancelQuit   = Components.classes["@mozilla.org/supports-PRBool;1"].createInstance(Components.interfaces.nsISupportsPRBool);
 	var observerSvc  = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-	var promptSvc  	 = Services.prompt;
 	var stringBundle = Services.strings.createBundle("chrome://classic_theme_restorer/locale/messages.file");
 						
 	var brandName	 = '';
@@ -458,7 +456,7 @@ classicthemerestorerjso.ctr = {
 	} catch(e) {}
 
 	if (this.needsRestart &&
-		promptSvc.confirm(null,
+		Services.prompt.confirm(null,
 			stringBundle.GetStringFromName("popup.title"),
 			stringBundle.formatStringFromName("popup.msg.restart", [brandName], 1)
 		)) {
@@ -466,7 +464,7 @@ classicthemerestorerjso.ctr = {
 		if(cancelQuit.data) { // The quit request has been cancelled.
 			return false;
 		};
-		app.quit(app.eAttemptQuit | app.eRestart);
+		Services.startup.quit(Services.startup.eRestart | Services.startup.eAttemptQuit);
 	}
 	
 	// save last selected categories/tabs

--- a/xpi/content/overlay.dtd
+++ b/xpi/content/overlay.dtd
@@ -1,4 +1,14 @@
-<!ENTITY brandShortName				"Firefox">
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
+<!ENTITY brandShortName				"&brandShortName;">
 <!ENTITY appmenu.tooltip			"Open menu">
 <!ENTITY tabCmd.label				"New Tab">
 <!ENTITY tabCmd.accesskey			"T">
@@ -50,7 +60,7 @@
 <!ENTITY quitApplicationCmdWin.accesskey	"x">
 <!ENTITY quitApplicationCmd.label		"Quit">
 <!ENTITY quitApplicationCmd.accesskey	"Q">
-<!ENTITY quitApplicationCmdMac.label	"Quit Firefox">
+<!ENTITY quitApplicationCmdMac.label	"Quit &brandShortName;">
 <!ENTITY quitApplicationCmd.accesskey	"Q">
 <!ENTITY bookmarksMenu.label			"Bookmarks">
 <!ENTITY showAllBookmarks2.label		"Show All Bookmarks">
@@ -76,12 +86,12 @@
 <!ENTITY viewCustomizeToolbar.label		"Customize…">
 <!ENTITY viewCustomizeToolbar.accesskey	"C">
 <!ENTITY helpMenuWin.label				"Help">
-<!ENTITY productHelp.label				"Firefox Help">
+<!ENTITY productHelp.label				"&brandShortName; Help">
 <!ENTITY appMenuGettingStarted.label	"Getting started">
 <!ENTITY productHelp.accesskey			"H">
 <!ENTITY helpKeyboardShortcuts.label	"Keyboard Shortcuts">
 <!ENTITY helpKeyboardShortcuts.accesskey	"K">
-<!ENTITY healthReport.label				"Firefox Health Report">
+<!ENTITY healthReport.label				"&brandShortName; Health Report">
 <!ENTITY healthReport.accesskey			"e">
 <!ENTITY helpTroubleshootingInfo.accesskey	"T">
 <!ENTITY helpTroubleshootingInfo.label	"Troubleshooting Information">
@@ -90,7 +100,7 @@
 <!ENTITY helpSafeMode.accesskey			"R">
 <!ENTITY helpSafeMode.label				"Restart with Add-ons Disabled…">
 <!ENTITY aboutProduct.accesskey			"A">
-<!ENTITY aboutProduct.label				"About Firefox">
+<!ENTITY aboutProduct.label				"About &brandShortName;">
 <!ENTITY bookmarksMenuButton.label		"Bookmarks">
 <!ENTITY bookmarksButton.tooltip		"Display your bookmarks">
 <!ENTITY viewBookmarksToolbar.label		"View Bookmarks Toolbar">

--- a/xpi/content/overlay.js
+++ b/xpi/content/overlay.js
@@ -60,9 +60,9 @@ classicthemerestorerjs.ctr = {
   prefs:				Services.prefs.getBranch("extensions.classicthemerestorer."),
   
   fxdefaulttheme:		Services.prefs.getBranch("general.skins.").getCharPref("selectedSkin") == 'classic/1.0',
-  osstring:				Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime).OS,
+  osstring:				Services.appinfo.OS,
   appversion:			parseInt(Services.prefs.getBranch("extensions.").getCharPref("lastAppVersion")),
-  stringBundle:			Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService).createBundle("chrome://classic_theme_restorer/locale/messages.file"),
+  stringBundle:			Services.strings.createBundle("chrome://classic_theme_restorer/locale/messages.file"),
   
   hideTTWithOneTab:		false,
   moveStarIntoUrlbar:	false,

--- a/xpi/locale/cs/options.dtd
+++ b/xpi/locale/cs/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Lišta doplňků">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Activity Indicator">
 <!ENTITY Ctr_sidebarbutton	"Postranní lišta">
 <!ENTITY Ctr_windowcontrols	"Min/max/zavřít (Fullscreen)">
-<!ENTITY Ctr_rr				"Restartujte Firefox!">
+<!ENTITY Ctr_rr				"Restartujte &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"Tlačítka">
 <!ENTITY Ctr_cuibutnormal	"Normální">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Panely pod adresním řádkem (v2) --- nastaveno [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"v2 is for some add-ons and complete themes only!">
 <!ENTITY Ctr_tabsontopI1	"Přidává atribut [tabsontop=true/false] pro">
-<!ENTITY Ctr_tabsintitlebar	"Záhlaví okna Firefox (předvolba about:config)">
+<!ENTITY Ctr_tabsintitlebar	"Záhlaví okna &brandShortName; (předvolba about:config)">
 <!ENTITY Ctr_tabwidthdef	"(výchozí)">
 <!ENTITY Ctr_tabwidthcla	"(klasický)">
 <!ENTITY Ctr_tabminheight	"Height:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Tlačítko zakázáno">
 <!ENTITY Ctr_appbutton1		"Tlačítko na nástrojové liště">
 <!ENTITY Ctr_appbutton1wt	"Tlačítko na nástrojové liště (pouze text)">
-<!ENTITY Ctr_appbutton2		"Tlačítko v záhlaví okna [Firefox]">
-<!ENTITY Ctr_appbutton2h	"Tlačítko v záhlaví okna [Firefox] (hidden)">
-<!ENTITY Ctr_appbutton2io	"Tlačítko v záhlaví okna [Firefox] (pouze ikona)">
+<!ENTITY Ctr_appbutton2		"Tlačítko v záhlaví okna [&brandShortName;]">
+<!ENTITY Ctr_appbutton2h	"Tlačítko v záhlaví okna [&brandShortName;] (hidden)">
+<!ENTITY Ctr_appbutton2io	"Tlačítko v záhlaví okna [&brandShortName;] (pouze ikona)">
 <!ENTITY Ctr_paneluibtweak	"Oranžový panel jako tlačítko na liště s panely">
 <!ENTITY Ctr_appbuttonc_o	"Oranžové tlačítko (výchozí)">
 <!ENTITY Ctr_appbuttonc_a	"Modré tlačítko (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"Bíle tlačítko">
 <!ENTITY Ctr_appbuttonc_cu	"Custom button color">
 <!ENTITY Ctr_appbuttonI1	"Doporučený restart">
-<!ENTITY Ctr_appbuttonI1e	"Není viditelné v záhlaví okna Windows OS, pouze v záhlaví okna Firefoxu!">
+<!ENTITY Ctr_appbuttonI1e	"Není viditelné v záhlaví okna Windows OS, pouze v záhlaví okna &brandShortName;u!">
 <!ENTITY Ctr_appbuttonI2	"Barva tlačítka jsou viditelné pouze v záhlaví okna nebo liště s panely!">
 <!ENTITY Ctr_alttbappb		"Alternativní ikony">
 <!ENTITY Ctr_appbutmhi		"Vyšší umístění (pokud na liště s panely)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Tlačítko nabídky: skrýt texty u ikon">
 <!ENTITY Ctr_menupopupscr	"Nabídky: zobrazit rolovací lištu místo šipek">
 
-<!ENTITY Ctr_fxmockup		"Firefox Mockup">
+<!ENTITY Ctr_fxmockup		"&brandShortName; Mockup">
 <!ENTITY Ctr_tabmokcolor	"Bílá barva pro tlačítka panelu (zavřít, nový, skupiny, seznam všech)">
 <!ENTITY Ctr_tabmokcolor2	"Bílá barva a tmavý stín pro text na neaktivních panelech">
 <!ENTITY Ctr_tabmokcolor3	"Bílá barva pro oddělovače panelů">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Additional Toolbars">
 <!ENTITY Ctr_extrabar0		"Additional Toolbar(s)">
 <!ENTITY Ctr_extrabar1		"Přídavná lišta">
-<!ENTITY Ctr_extrabarinfo	"Switching between 'tabs on top' and 'tabs not on top' modes randomly alters additional toolbars order. Firefox has to be restarted to solve this issue.">
+<!ENTITY Ctr_extrabarinfo	"Switching between 'tabs on top' and 'tabs not on top' modes randomly alters additional toolbars order. &brandShortName; has to be restarted to solve this issue.">
 
 <!ENTITY Ctr_invicons		"Invertované ikony">
 <!ENTITY Ctr_menubar		"Hlavní nabídka">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"In maximized mode (tabs on top)">
 
 <!ENTITY Ctr_altmenubar		"Přidat barvu pozadí (lišta záhlaví OS)">
-<!ENTITY Ctr_altmenubarpos	"Alternativní umístění (pod lištou záhlaví Firefox)">
+<!ENTITY Ctr_altmenubarpos	"Alternativní umístění (pod lištou záhlaví &brandShortName;)">
 <!ENTITY Ctr_menubarnofog	"Odstranit barevné/zamlžené pozadí (Windows AeroGlass/8)">
 
 <!ENTITY Ctr_aerocolors		"Blue Aero colors for main toolbars and tabs">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prevent 'Developer Theme' from being enabled">
 
 <!ENTITY Ctr_experttweaks	"Advanced">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ introduced 'new render features' currently responsible for 'hanging tabs' on some systems. Unchecking this preference resolves this issue.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ introduced a 'new seach ui'. Unchecking this preference returns the 'old seach ui'.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ introduced 'calling and conversation' features. Unchecking this preference removes them.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ introduced 'new render features' currently responsible for 'hanging tabs' on some systems. Unchecking this preference resolves this issue.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ introduced a 'new seach ui'. Unchecking this preference returns the 'old seach ui'.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ introduced 'calling and conversation' features. Unchecking this preference removes them.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Možnosti">
 <!ENTITY Ctr_pw_set_reset	"Obnovit výchozí">
 <!ENTITY Ctr_pw_set_predef	"Nastavit klasické">
-<!ENTITY Ctr_pw_set_preaus	"Firefox preset">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; preset">
 <!ENTITY Ctr_pw_set_export	"Exportovat nastavení">
 <!ENTITY Ctr_pw_set_import	"Importovat nastavení">
 
 <!ENTITY Ctr_special_font	"Nastavení pozadí ovlivní pouze výchoz vzhled!">
 <!ENTITY Ctr_special_info	"Některé volby nemusí v některých případech vzhled vůbec ovlivnit">
-<!ENTITY Ctr_special_info2	"Možnosti jsou pro výchozí vzhled Firefoxu a nemusí fungovat s jinými nainstalovanými vzhledy!">
+<!ENTITY Ctr_special_info2	"Možnosti jsou pro výchozí vzhled &brandShortName;u a nemusí fungovat s jinými nainstalovanými vzhledy!">
 <!ENTITY Ctr_support		"Fórum podpory">
 <!ENTITY Ctr_newversion		"Nová verze?">
 

--- a/xpi/locale/da/options.dtd
+++ b/xpi/locale/da/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Tilføjelseslinje">
@@ -25,7 +35,7 @@
 <!ENTITY Ctr_tabcolors_t	"Faneblade farver &amp; tekst">
 
 <!ENTITY Ctr_tabs			"Faneblade">
-<!ENTITY Ctr_tabs0			"Afrundede faneblade (Firefox standard)">
+<!ENTITY Ctr_tabs0			"Afrundede faneblade (&brandShortName; standard)">
 <!ENTITY Ctr_tabs1			"Firkantede faneblade (klassisk)">
 <!ENTITY Ctr_tabs1m			"Firkantede faneblade (australisifiseret)">
 <!ENTITY Ctr_tabs2			"Afrundede faneblade (alternativ)">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Faneblade skal ikke være øverst (v2) --- [tabsontop=false] attribut">
 <!ENTITY Ctr_tabsontopW1	"v2 er kun til nogle tilføjelser og komplette temaer!">
 <!ENTITY Ctr_tabsontopI1	"Attributten [tabsontop=true/false] bliver tilføjet">
-<!ENTITY Ctr_tabsintitlebar	"Firefox i titellinjen (about:config)">
+<!ENTITY Ctr_tabsintitlebar	"&brandShortName; i titellinjen (about:config)">
 <!ENTITY Ctr_tabwidthdef	"(standard)">
 <!ENTITY Ctr_tabwidthcla	"(klassisk)">
 <!ENTITY Ctr_tabminheight	"Højde:">
@@ -66,13 +76,13 @@
 <!ENTITY Ctr_hctpinfotab	"Some tab variations are not compatible to 'Hide Caption Titlebar Plus' add-on.">
 <!ENTITY Ctr_hctpinfoab		"Button on titlebar is not compatible to 'Hide Caption Titlebar Plus' add-on.">
 
-<!ENTITY Ctr_appbutton		"Firefox-menuknap">
+<!ENTITY Ctr_appbutton		"&brandShortName;-menuknap">
 <!ENTITY Ctr_appbutton0		"Deaktiver knap">
 <!ENTITY Ctr_appbutton1		"Knap på værktøjslinje">
 <!ENTITY Ctr_appbutton1wt	"Knap på værktøjslinje (kun tekst)">
-<!ENTITY Ctr_appbutton2		"Knap på [Firefox] titellinje">
-<!ENTITY Ctr_appbutton2h	"Knap på [Firefox] titellinje (skjul)">
-<!ENTITY Ctr_appbutton2io	"Knap på [Firefox] titellinje (kun ikon)">
+<!ENTITY Ctr_appbutton2		"Knap på [&brandShortName;] titellinje">
+<!ENTITY Ctr_appbutton2h	"Knap på [&brandShortName;] titellinje (skjul)">
+<!ENTITY Ctr_appbutton2io	"Knap på [&brandShortName;] titellinje (kun ikon)">
 <!ENTITY Ctr_paneluibtweak	"Orange panelmenu knap på fanebladslinjen">
 <!ENTITY Ctr_appbuttonc_o	"Orange knap (standard)">
 <!ENTITY Ctr_appbuttonc_a	"Blå knap (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"Hvid knap">
 <!ENTITY Ctr_appbuttonc_cu	"Tilpas knap">
 <!ENTITY Ctr_appbuttonI1	"Genstart anbefales">
-<!ENTITY Ctr_appbuttonI1e	"Ikke synlig i Windows OS titellinjen, kun i Firefox titellinjen!">
+<!ENTITY Ctr_appbuttonI1e	"Ikke synlig i Windows OS titellinjen, kun i &brandShortName; titellinjen!">
 <!ENTITY Ctr_appbuttonI2	"Farverne på knapperne er kun synlige i titellinjen og fanebladslinjen!">
 <!ENTITY Ctr_alttbappb		"Alternative ikoner uden rullemenu-pil">
 <!ENTITY Ctr_appbutmhi		"Højere placering (hvis på fanebladslinje)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Panelmenu popup: skjul mærkater på knapper">
 <!ENTITY Ctr_menupopupscr	"Menupopups: vis rullepaneler i stedet for rullepile">
 
-<!ENTITY Ctr_fxmockup		"Firefox model">
+<!ENTITY Ctr_fxmockup		"&brandShortName; model">
 <!ENTITY Ctr_tabmokcolor	"Hvid farve til fanebladsknapper (luk, nyt, grupper, list alle)">
 <!ENTITY Ctr_tabmokcolor2	"Hvid farve og sort skygge til tekst på ikke-aktive faneblade">
 <!ENTITY Ctr_tabmokcolor3	"Hvid farve til fanebladesseparatorer">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Yderligere værktøjslinjer">
 <!ENTITY Ctr_extrabar0		"Yderligere værktøjslinje(r)">
 <!ENTITY Ctr_extrabar1		"Yderligere værktøjslinje">
-<!ENTITY Ctr_extrabarinfo	"Skifte mellem 'faneblade øverst' og 'faneblade skal ikke være øverst' ændre tilfældigt på rækkefølgen af yderligere værktøjslinjer. Firefox skal genstartes for at løse dette problem.">
+<!ENTITY Ctr_extrabarinfo	"Skifte mellem 'faneblade øverst' og 'faneblade skal ikke være øverst' ændre tilfældigt på rækkefølgen af yderligere værktøjslinjer. &brandShortName; skal genstartes for at løse dette problem.">
 
 <!ENTITY Ctr_invicons		"Omvendt farvede ikoner">
 <!ENTITY Ctr_menubar		"Menulinje">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"In maximized mode (tabs on top)">
 
 <!ENTITY Ctr_altmenubar		"Tilføj baggrundsfarve (OS titellinje)">
-<!ENTITY Ctr_altmenubarpos	"Alternativ placering (under Firefox titellinje)">
+<!ENTITY Ctr_altmenubarpos	"Alternativ placering (under &brandShortName; titellinje)">
 <!ENTITY Ctr_menubarnofog	"Fjern baggrundsfarve/tåge (Windows AeroGlass/8)">
 
 <!ENTITY Ctr_aerocolors		"Blå Aero farver til værktøjslinjer (og faneblade)">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prevent 'Developer Theme' from being enabled">
 
 <!ENTITY Ctr_experttweaks	"Avanceret">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ introducerede 'nye renderingsfunktioner' som i øjeblikket er skyld i 'faneblade som hænger' på nogle systemer. Fjern markeringen for at rette problem.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ introducerede 'en ny brugerflade til søgning'. Fjern markeringen for at vende tilbage til den 'gamle brugerflade'.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ introducerede 'opkald og samtaler'. Fjern markeringen ved denne indstilling for at fjerne funktionen.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ introducerede 'nye renderingsfunktioner' som i øjeblikket er skyld i 'faneblade som hænger' på nogle systemer. Fjern markeringen for at rette problem.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ introducerede 'en ny brugerflade til søgning'. Fjern markeringen for at vende tilbage til den 'gamle brugerflade'.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ introducerede 'opkald og samtaler'. Fjern markeringen ved denne indstilling for at fjerne funktionen.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Indstillinger">
 <!ENTITY Ctr_pw_set_reset	"Gendan standard">
 <!ENTITY Ctr_pw_set_predef	"Klassisk opsætning">
-<!ENTITY Ctr_pw_set_preaus	"Firefox opsætning">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; opsætning">
 <!ENTITY Ctr_pw_set_export	"Eksporter indstillinger">
 <!ENTITY Ctr_pw_set_import	"Importer indstillinger">
 
 <!ENTITY Ctr_special_font	"Indstillinger til baggrundsfarve gælder kun til standard tema!">
 <!ENTITY Ctr_special_info	"Nogle valgmuligheder giver måske ikke altid synlige ændringer">
-<!ENTITY Ctr_special_info2	"Indstillinger foretages til Firefox standard tema og virker måske ikke med alle tredjeparts temaer!">
+<!ENTITY Ctr_special_info2	"Indstillinger foretages til &brandShortName; standard tema og virker måske ikke med alle tredjeparts temaer!">
 <!ENTITY Ctr_support		"Supportforum">
 <!ENTITY Ctr_newversion		"Ny version?">
 

--- a/xpi/locale/de/options.dtd
+++ b/xpi/locale/de/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Addonleiste">
@@ -25,7 +35,7 @@
 <!ENTITY Ctr_tabcolors_t	"Tab Farben / Zeichensatz">
 
 <!ENTITY Ctr_tabs			"Tabs">
-<!ENTITY Ctr_tabs0			"Gerundete Tabs (Firefox-Standard)">
+<!ENTITY Ctr_tabs0			"Gerundete Tabs (&brandShortName;-Standard)">
 <!ENTITY Ctr_tabs1			"Quadratische Tabs (klassisch)">
 <!ENTITY Ctr_tabs1m			"Quadratische Tabs (australisiert)">
 <!ENTITY Ctr_tabs2			"Gerundete Tabs (alternativ)">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Tabs unten (v2) --- '[tabsontop=false]' Attribut gesetzt">
 <!ENTITY Ctr_tabsontopW1	"v2 ist nur für einige Add-ons und vollständige Themen sinnvoll!">
 <!ENTITY Ctr_tabsontopI1	"[tabsontop=true/false] Attribut wird gesetzt für">
-<!ENTITY Ctr_tabsintitlebar	"Firefox Titelleiste (about:config Einstellung)">
+<!ENTITY Ctr_tabsintitlebar	"&brandShortName; Titelleiste (about:config Einstellung)">
 <!ENTITY Ctr_tabwidthdef	"(Standard)">
 <!ENTITY Ctr_tabwidthcla	"(klassisch)">
 <!ENTITY Ctr_tabminheight	"Höhe:">
@@ -66,13 +76,13 @@
 <!ENTITY Ctr_hctpinfotab	"Einige Tabvarianten sind nicht kompatibel zu 'Hide Caption Titlebar Plus'.">
 <!ENTITY Ctr_hctpinfoab		"Die Titelleisten-Schaltfläche ist nicht kompatibel zu 'Hide Caption Titlebar Plus'.">
 
-<!ENTITY Ctr_appbutton		"Firefox-Schaltfläche">
+<!ENTITY Ctr_appbutton		"&brandShortName;-Schaltfläche">
 <!ENTITY Ctr_appbutton0		"Deaktiviert">
 <!ENTITY Ctr_appbutton1		"Auf den Symbolleisten">
 <!ENTITY Ctr_appbutton1wt	"Auf den Symbolleisten (nur Text)">
-<!ENTITY Ctr_appbutton2		"Auf der Firefox Titelleiste">
-<!ENTITY Ctr_appbutton2h	"Auf der Firefox Titelleiste (versteckt)">
-<!ENTITY Ctr_appbutton2io	"Auf der Firefox Titelleiste (nur Symbol)">
+<!ENTITY Ctr_appbutton2		"Auf der &brandShortName; Titelleiste">
+<!ENTITY Ctr_appbutton2h	"Auf der &brandShortName; Titelleiste (versteckt)">
+<!ENTITY Ctr_appbutton2io	"Auf der &brandShortName; Titelleiste (nur Symbol)">
 <!ENTITY Ctr_paneluibtweak	"Orange Menüschaltfläche auf der Tableiste">
 <!ENTITY Ctr_appbuttonc_o	"Farbe: orange (Standard)">
 <!ENTITY Ctr_appbuttonc_a	"Farbe: blau (Aurora)">
@@ -86,13 +96,13 @@
 <!ENTITY Ctr_appbuttonc_wh	"Farbe: weiß">
 <!ENTITY Ctr_appbuttonc_cu	"Farbe: eigene Definition">
 <!ENTITY Ctr_appbuttonI1	"Nach einer Änderung wird ein Neustart empfohlen.">
-<!ENTITY Ctr_appbuttonI1e	"Die Firefox-Schaltfläche ist auf der Windows Titelleiste nicht sichtbar!">
+<!ENTITY Ctr_appbuttonI1e	"Die &brandShortName;-Schaltfläche ist auf der Windows Titelleiste nicht sichtbar!">
 <!ENTITY Ctr_appbuttonI2	"Die Farbe ist nur auf der Titelleiste und der Tableiste sichtbar!">
 <!ENTITY Ctr_alttbappb		"Alternative Symbole">
 <!ENTITY Ctr_appbutmhi		"Höhere Position (wenn auf der Tableiste)">
 <!ENTITY Ctr_appbutbdl		"Entferne Ränder und Hintergrundfarbe">
 <!ENTITY Ctr_dblclclosefx	"Doppelklick schließt aktuelles Fenster">
-<!ENTITY Ctr_appbclmmenus	"Klickbare Menüs im 'Firefox-Menü' (Neuer Tab, Drucken...)">
+<!ENTITY Ctr_appbclmmenus	"Klickbare Menüs im '&brandShortName;-Menü' (Neuer Tab, Drucken...)">
 <!ENTITY Ctr_appbutonclab	"Titel">
 <!ENTITY Ctr_appbutonclab2	"Titel eintragen oder leer lassen">
 
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Menüschaltflächen-Aufklappmenü: verstecke Schaltflächen-Text">
 <!ENTITY Ctr_menupopupscr	"Aufklappmenüs: ersetze Navigationspfeile durch Bildlaufleisten">
 
-<!ENTITY Ctr_fxmockup		"Firefox Entwürfe">
+<!ENTITY Ctr_fxmockup		"&brandShortName; Entwürfe">
 <!ENTITY Ctr_tabmokcolor	"Weiße Schaltflächen (Neu, Schließen, Gruppen, Listen)">
 <!ENTITY Ctr_tabmokcolor2	"Weißer Tabtext und dunkler Schatten für nicht aktive Tabs">
 <!ENTITY Ctr_tabmokcolor3	"Weiße Trennlinien zwischen den Tabs">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Extraleisten">
 <!ENTITY Ctr_extrabar0		"Extraleiste(n)">
 <!ENTITY Ctr_extrabar1		"Extraleiste">
-<!ENTITY Ctr_extrabarinfo	"Der Wechsel zwischen 'Tabs oben' und 'Tabs unten' kann die Reihenfolge der Extraleisten ändern. Ein Firefox-Neustart stellt die richtige Reihenfolge wieder her.">
+<!ENTITY Ctr_extrabarinfo	"Der Wechsel zwischen 'Tabs oben' und 'Tabs unten' kann die Reihenfolge der Extraleisten ändern. Ein &brandShortName;-Neustart stellt die richtige Reihenfolge wieder her.">
 
 <!ENTITY Ctr_invicons		"Invertierte Symbole">
 <!ENTITY Ctr_menubar		"Menüleiste">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"Im maximierten Fenster (Tabs oben)">
 
 <!ENTITY Ctr_altmenubar		"Hintergrundfarbe hinzufügen ('System Titelleiste')">
-<!ENTITY Ctr_altmenubarpos	"Alternative Position (unter der Firefox Titelleiste)">
+<!ENTITY Ctr_altmenubarpos	"Alternative Position (unter der &brandShortName; Titelleiste)">
 <!ENTITY Ctr_menubarnofog	"Hintergrundfarbe/-nebel entfernen (Windows AeroGlass / Win8)">
 
 <!ENTITY Ctr_aerocolors		"Blaue 'Aero' Farben für Leisten (und Tabs)">
@@ -242,7 +252,7 @@
 <!ENTITY Ctr_dlanimation	"'Download gestartet und beendet' (about:config Einstellung)">
 
 <!ENTITY Ctr_toolsitem		"Eintrag im Menü 'Extras'">
-<!ENTITY Ctr_appmenuitem	"Eintrag im Einstellungsuntermenü der Firefox-Schaltfläche">
+<!ENTITY Ctr_appmenuitem	"Eintrag im Einstellungsuntermenü der &brandShortName;-Schaltfläche">
 <!ENTITY Ctr_contextitem	"Eintrag im Leisten-Kontextmenü">
 <!ENTITY Ctr_puictrbutton	"Eintrag in der Hauptmenüschaltfläche">
 
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Verhindere die Aktivierung des 'Entwickler Themas'">
 
 <!ENTITY Ctr_experttweaks	"Erweitert">
-<!ENTITY Ctr_fx33layers		"Mit Firefox 33+ wurden neue 'Render-Funktionen' eingeführt, die zurzeit für 'nicht reagierende und einfrierende Tabs' auf einigen Systemen sorgen. Das Deaktivieren dieser Option kann das Problem lösen.">
-<!ENTITY Ctr_fx34search		"Mit Firefox 34+ wurde eine neue 'Suchoberfläche' eingeführt. Das Deaktivieren dieser Option stellt die 'alte Suchoberfläche' wieder her.">
-<!ENTITY Ctr_fx34loop		"Mit Firefox 34+ wurden 'Anruf- und Konversations-Funktionen' eingeführt. Das Deaktivieren dieser Option entfernt diese Funktionen.">
-<!ENTITY Ctr_fx35devtheme	"Mit Firefox 35+ wurde ein neues 'Entwickler-Thema' eingeführt. Das Deaktivieren dieser Optionen stellt das 'Standard-Thema' wieder her und entfernt die zugehörige Schaltfläche im Modus 'Anpassen'.">
-<!ENTITY Ctr_fx36prefs		"Mit Firefox 36+ wurden 'Einstellungen im Tab' eingeführt. Das Deaktivieren dieser Option stellt das 'alte' Einstellungsfenster wieder her.">
+<!ENTITY Ctr_fx33layers		"Mit &brandShortName; 33+ wurden neue 'Render-Funktionen' eingeführt, die zurzeit für 'nicht reagierende und einfrierende Tabs' auf einigen Systemen sorgen. Das Deaktivieren dieser Option kann das Problem lösen.">
+<!ENTITY Ctr_fx34search		"Mit &brandShortName; 34+ wurde eine neue 'Suchoberfläche' eingeführt. Das Deaktivieren dieser Option stellt die 'alte Suchoberfläche' wieder her.">
+<!ENTITY Ctr_fx34loop		"Mit &brandShortName; 34+ wurden 'Anruf- und Konversations-Funktionen' eingeführt. Das Deaktivieren dieser Option entfernt diese Funktionen.">
+<!ENTITY Ctr_fx35devtheme	"Mit &brandShortName; 35+ wurde ein neues 'Entwickler-Thema' eingeführt. Das Deaktivieren dieser Optionen stellt das 'Standard-Thema' wieder her und entfernt die zugehörige Schaltfläche im Modus 'Anpassen'.">
+<!ENTITY Ctr_fx36prefs		"Mit &brandShortName; 36+ wurden 'Einstellungen im Tab' eingeführt. Das Deaktivieren dieser Option stellt das 'alte' Einstellungsfenster wieder her.">
 <!ENTITY Ctr_e_omtc			"OMTC / Problem mit 'einfrierenden Tabs'">
 <!ENTITY Ctr_e_searchui		"Suchoberfläche">
 <!ENTITY Ctr_e_loop			"Anruf- und Konversations-Funktionen">
@@ -267,7 +277,7 @@
 <!ENTITY Ctr_pw_settings	"Einstellungen">
 <!ENTITY Ctr_pw_set_reset	"Standard wiederherstellen">
 <!ENTITY Ctr_pw_set_predef	"Klassische Vorgabe">
-<!ENTITY Ctr_pw_set_preaus	"Firefox Vorgabe">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; Vorgabe">
 <!ENTITY Ctr_pw_set_export	"Exportiere Einstellungen">
 <!ENTITY Ctr_pw_set_import	"Importiere Einstellungen">
 

--- a/xpi/locale/dsb/options.dtd
+++ b/xpi/locale/dsb/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Rědka dodankow">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Pokazka aktiwity">
 <!ENTITY Ctr_sidebarbutton	"Bócnica">
 <!ENTITY Ctr_windowcontrols	"Min./maks./zacyniś (połna wobrazowka)">
-<!ENTITY Ctr_rr				"Startujśo Firefox znowego!">
+<!ENTITY Ctr_rr				"Startujśo &brandShortName; znowego!">
 
 <!ENTITY Ctr_cuibuttons		"Tłocaški">
 <!ENTITY Ctr_cuibutnormal	"Normalny">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Rejtarki nic górjejce (v2) --- stajśo [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"v2 jo jano za někotare dodanki a dopołne drastwy!">
 <!ENTITY Ctr_tabsontopI1	"Pśidawa atribut [tabsontop=true/false] na">
-<!ENTITY Ctr_tabsintitlebar	"Titelowa rědka Firefox (about:config)">
+<!ENTITY Ctr_tabsintitlebar	"Titelowa rědka &brandShortName; (about:config)">
 <!ENTITY Ctr_tabwidthdef	"(standard)">
 <!ENTITY Ctr_tabwidthcla	"(klasiski)">
 <!ENTITY Ctr_tabminheight	"Wusokosć:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Tłocašk znjemóžnjony">
 <!ENTITY Ctr_appbutton1		"Tłocašk na symbolowej rědce">
 <!ENTITY Ctr_appbutton1wt	"Tłocašk na symbolowej rědce (jano tekst)">
-<!ENTITY Ctr_appbutton2		"Tłocašk na titelowej rědce [Firefox]">
+<!ENTITY Ctr_appbutton2		"Tłocašk na titelowej rědce [&brandShortName;]">
 <!ENTITY Ctr_appbutton2h	"Tłocašk na titelowej rědce (schowany)">
-<!ENTITY Ctr_appbutton2io	"Tłocašk na titelowej rědce [Firefox] (jano symbol)">
+<!ENTITY Ctr_appbutton2io	"Tłocašk na titelowej rědce [&brandShortName;] (jano symbol)">
 <!ENTITY Ctr_paneluibtweak	"Oranžowy menijowy tłocašk na rejtarkowej rědce">
 <!ENTITY Ctr_appbuttonc_o	"Tłocaškowa barwa: Oranžowy (standard)">
 <!ENTITY Ctr_appbuttonc_a	"Tłocaškkowa barwa: Módry (Aurora)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Pólowy meni: Tekst tłocaškow schowaś">
 <!ENTITY Ctr_menupopupscr	"Wuskokujuce menije: suwate rědki město suwatych šypkow pokazaś">
 
-<!ENTITY Ctr_fxmockup		"Nacerjenje Firefox">
+<!ENTITY Ctr_fxmockup		"Nacerjenje &brandShortName;">
 <!ENTITY Ctr_tabmokcolor	"Běła barwa za rejtarkowe tłocaški (zacyniś, nowy, kupki, wšykne nalicyś)">
 <!ENTITY Ctr_tabmokcolor2	"Běła barwa a śamna wóseń za tekst na njeaktiwnych rejtarkach">
 <!ENTITY Ctr_tabmokcolor3	"Běła barwa za rejtarkowe źěleńske smužki">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Pśidatne symbolowe rědki">
 <!ENTITY Ctr_extrabar0		"Pśidatne symbolowe rědki">
 <!ENTITY Ctr_extrabar1		"Pśidatna symbolowa rědka">
-<!ENTITY Ctr_extrabarinfo	"Pśešaltowanje mjazy 'rejtarki górjejce' a 'rejtarki dołojce' móžo rěd pśidatnych rědkow pśipadnje změniś. Firefox musy se znowego startowaś, aby toś ten problem rozwězał.">
+<!ENTITY Ctr_extrabarinfo	"Pśešaltowanje mjazy 'rejtarki górjejce' a 'rejtarki dołojce' móžo rěd pśidatnych rědkow pśipadnje změniś. &brandShortName; musy se znowego startowaś, aby toś ten problem rozwězał.">
 
 <!ENTITY Ctr_invicons		"Inwertěrowane symbole">
 <!ENTITY Ctr_menubar		"Menijowa rědka">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"W maksiměrowanem naglěźe (rejtarki górjejce)">
 
 <!ENTITY Ctr_altmenubar		"Slězynowu barwu pśidaś (titelowa rědka źěłowego systema)">
-<!ENTITY Ctr_altmenubarpos	"Alternatiwna pozicija (pód titeloweju rědku Firefox)">
+<!ENTITY Ctr_altmenubarpos	"Alternatiwna pozicija (pód titeloweju rědku &brandShortName;)">
 <!ENTITY Ctr_menubarnofog	"Slězynowu barwu/młu wótpóraś (Windows AeroGlass / Win8)">
 
 <!ENTITY Ctr_aerocolors		"Barwy 'Blue Aero' za głowne rědki a rejtarki">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Zmóžnjenjeju 'wuwijarskeje drastwy' zajźowaś">
 
 <!ENTITY Ctr_experttweaks	"Rozšyrjone">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ jo 'nowe kresleńske funkcije' zawjadł, kótarež su tuchylu zagronite za 'njereagěrujuce rejtarki' na někotarych systemach. Gaž znjemóžnijośo toś to nastajenje, rozwěžośo toś ten problem.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ jo 'nowy pytański pówjerch' zawjadł. Gaž znjemóžnijośo toś to nastajenje, wótnowijośo 'stary pytański pówjerch'.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ jo 'telefoněrowańske a konwersaciske' funkcije zawjadł. Gaž znjemóžnijośo toś to nastajenje, se wótpóraju.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ jo nowu 'wuwijarsku drastwu' zawjadł. Gaž znjemóžnijośo toś te nastajenja, se 'wuwijarska drastwa' a jeje tłocašk w pśiměrjeńskem modusu znjemóžnjatej.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ jo 'nastajenja w rejtarku' zawjadł. Gaž znjemóžnijośo toś to nastajenje, se stare wokno nastajenjow wótnowijo..">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ jo 'nowe kresleńske funkcije' zawjadł, kótarež su tuchylu zagronite za 'njereagěrujuce rejtarki' na někotarych systemach. Gaž znjemóžnijośo toś to nastajenje, rozwěžośo toś ten problem.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ jo 'nowy pytański pówjerch' zawjadł. Gaž znjemóžnijośo toś to nastajenje, wótnowijośo 'stary pytański pówjerch'.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ jo 'telefoněrowańske a konwersaciske' funkcije zawjadł. Gaž znjemóžnijośo toś to nastajenje, se wótpóraju.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ jo nowu 'wuwijarsku drastwu' zawjadł. Gaž znjemóžnijośo toś te nastajenja, se 'wuwijarska drastwa' a jeje tłocašk w pśiměrjeńskem modusu znjemóžnjatej.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ jo 'nastajenja w rejtarku' zawjadł. Gaž znjemóžnijośo toś to nastajenje, se stare wokno nastajenjow wótnowijo..">
 <!ENTITY Ctr_e_omtc			"OMTC / problem z wisecymi rejtarkami">
 <!ENTITY Ctr_e_searchui		"Pytański pówjerch">
 <!ENTITY Ctr_e_loop			"Telefoněrowanje a konwersacija">
@@ -267,7 +277,7 @@
 <!ENTITY Ctr_pw_settings	"Nastajenja">
 <!ENTITY Ctr_pw_set_reset	"Standard wótnowiś">
 <!ENTITY Ctr_pw_set_predef	"Klasiske standardne gódnoty">
-<!ENTITY Ctr_pw_set_preaus	"Standard Firefox">
+<!ENTITY Ctr_pw_set_preaus	"Standard &brandShortName;">
 <!ENTITY Ctr_pw_set_export	"Nastajenja eksportěrowaś">
 <!ENTITY Ctr_pw_set_import	"Nastajenja importěrowaś">
 

--- a/xpi/locale/el/options.dtd
+++ b/xpi/locale/el/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Επαναφορέας κλασικού θέματος">
 
 <!ENTITY Ctr_addonbar		"Εργαλειοθήκη πρόσθετων">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Ενδείκτης δραστηριότητας">
 <!ENTITY Ctr_sidebarbutton	"(Πλευρική στήλη)">
 <!ENTITY Ctr_windowcontrols	"Ελαχιστοποίηση/επαναφορά/κλείσιμο (Πλήρης οθόνη)">
-<!ENTITY Ctr_rr				"Επανεκκινήστε τον Firefox!">
+<!ENTITY Ctr_rr				"Επανεκκινήστε τον &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"Κουμπιά">
 <!ENTITY Ctr_cuibutnormal	"Κανονικά">
@@ -25,7 +35,7 @@
 <!ENTITY Ctr_tabcolors_t	"Χρώματα καρτελών &amp; κειμένου">
 
 <!ENTITY Ctr_tabs			"Καρτέλες">
-<!ENTITY Ctr_tabs0			"Καμπυλόγραμμες καρτέλες (προεπιλογή Firefox)">
+<!ENTITY Ctr_tabs0			"Καμπυλόγραμμες καρτέλες (προεπιλογή &brandShortName;)">
 <!ENTITY Ctr_tabs1			"Τετραγωνισμένες καρτέλες (κλασική τεχνοτροπία)">
 <!ENTITY Ctr_tabs1m			"Τετραγωνισμένες καρτέλες (τεχνοτροπία Australis)">
 <!ENTITY Ctr_tabs2			"Καμπυλόγραμμες καρτέλες (εναλλακτική τεχνοτροπία)">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Καρτέλες όχι στο πάνω μέρος (v2) --- ορισμός χαρακτηριστικού [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"Η v2 είναι για ορισμένες επεκτάσεις και πλήρη θέματα μόνο!">
 <!ENTITY Ctr_tabsontopI1	"Προσθέτει χαρακτηριστικό [tabsontop=true/false] σε">
-<!ENTITY Ctr_tabsintitlebar	"Γραμμή τίτλου Firefox (προτίμηση about:config)">
+<!ENTITY Ctr_tabsintitlebar	"Γραμμή τίτλου &brandShortName; (προτίμηση about:config)">
 <!ENTITY Ctr_tabwidthdef	"(προεπιλογή)">
 <!ENTITY Ctr_tabwidthcla	"(κλασικό)">
 <!ENTITY Ctr_tabminheight	"Ύψος:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Απενεργοποιημένο">
 <!ENTITY Ctr_appbutton1		"Στην εργαλειοθήκη">
 <!ENTITY Ctr_appbutton1wt	"Στην εργαλειοθήκη (μόνο κείμενο)">
-<!ENTITY Ctr_appbutton2		"Στη γραμμή τίτλου [Firefox]">
-<!ENTITY Ctr_appbutton2h	"Στη γραμμή τίτλου [Firefox] (σε απόκρυψη)">
-<!ENTITY Ctr_appbutton2io	"Στη γραμμή τίτλου [Firefox] (μόνο εικονίδιο)">
+<!ENTITY Ctr_appbutton2		"Στη γραμμή τίτλου [&brandShortName;]">
+<!ENTITY Ctr_appbutton2h	"Στη γραμμή τίτλου [&brandShortName;] (σε απόκρυψη)">
+<!ENTITY Ctr_appbutton2io	"Στη γραμμή τίτλου [&brandShortName;] (μόνο εικονίδιο)">
 <!ENTITY Ctr_paneluibtweak	"Πορτοκαλί κουμπί μενού πίνακα στην εργαλειοθήκη καρτελών">
 <!ENTITY Ctr_appbuttonc_o	"Πορτοκαλί χρώμα κουμπιού (προεπιλογή)">
 <!ENTITY Ctr_appbuttonc_a	"Μπλε χρώμα κουμπιού (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"Άσπρο χρώμα κουμπιού">
 <!ENTITY Ctr_appbuttonc_cu	"Προσαρμοσμένο χρώμα κουμπιού">
 <!ENTITY Ctr_appbuttonI1	"Συνιστάται επανεκκίνηση">
-<!ENTITY Ctr_appbuttonI1e	"Δεν είναι ορατό στη γραμμή τίτλου του Λ.Σ. Windows, μόνο στη γραμμή τίτλου του Firefox!">
+<!ENTITY Ctr_appbuttonI1e	"Δεν είναι ορατό στη γραμμή τίτλου του Λ.Σ. Windows, μόνο στη γραμμή τίτλου του &brandShortName;!">
 <!ENTITY Ctr_appbuttonI2	"Τα χρώματα του κουμπιού είναι ορατά μόνο στη γραμμή τίτλου και στην εργαλειοθήκη καρτελών!">
 <!ENTITY Ctr_alttbappb		"Εναλλακτικά εικονίδια χωρίς δείκτη ανάπτυξης">
 <!ENTITY Ctr_appbutmhi		"Υψηλότερη θέση (εάν είναι στην εργαλειοθήκη καρτελών)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Μενού πίνακα: απόκρυψη ετικετών κουμπιών">
 <!ENTITY Ctr_menupopupscr	"Αναδυόμενα μενού: εμφάνιση γραμμών κύλισης αντί για βέλη κύλισης">
 
-<!ENTITY Ctr_fxmockup		"Μακέτα Firefox">
+<!ENTITY Ctr_fxmockup		"Μακέτα &brandShortName;">
 <!ENTITY Ctr_tabmokcolor	"Άσπρο χρώμα κουμπιών καρτελών (κλείσιμο, νέα, ομάδες, λίστα όλων)">
 <!ENTITY Ctr_tabmokcolor2	"Άσπρο χρώμα και σκοτεινή σκιά κειμένου μη ενεργών καρτελών">
 <!ENTITY Ctr_tabmokcolor3	"Άσπρο χρώμα διαχωριστικών καρτελών">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Επιπρόσθετες εργαλειοθήκες">
 <!ENTITY Ctr_extrabar0		"Επιπρόσθετη/ες εργαλειοθήκη/ες">
 <!ENTITY Ctr_extrabar1		"Επιπρόσθετη εργαλειοθήκη">
-<!ENTITY Ctr_extrabarinfo	"Η εναλλαγή λειτουργιών «Καρτέλες στο πάνω μέρος» και «Καρτέλες όχι στο πάνω μέρος», αλλάζει τυχαία τη σειρά των επιπρόσθετων εργαλειοθηκών. Ο Firefox πρέπει να επανεκκινηθεί για αντιμετώπιση αυτού του θέματος.">
+<!ENTITY Ctr_extrabarinfo	"Η εναλλαγή λειτουργιών «Καρτέλες στο πάνω μέρος» και «Καρτέλες όχι στο πάνω μέρος», αλλάζει τυχαία τη σειρά των επιπρόσθετων εργαλειοθηκών. Ο &brandShortName; πρέπει να επανεκκινηθεί για αντιμετώπιση αυτού του θέματος.">
 
 <!ENTITY Ctr_invicons		"Ανεστραμμένα εικονίδια">
 <!ENTITY Ctr_menubar		"Εργαλειοθήκη μενού">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"Σε λειτουργία μεγιστοποίησης (καρτέλες στο πάνω μέρος)">
 
 <!ENTITY Ctr_altmenubar		"Προσθήκη χρώματος φόντου (γραμμή τίτλου Λ.Σ.)">
-<!ENTITY Ctr_altmenubarpos	"Εναλλακτική θέση (παρακάτω από τη γραμμή τίτλου του Firefox)">
+<!ENTITY Ctr_altmenubarpos	"Εναλλακτική θέση (παρακάτω από τη γραμμή τίτλου του &brandShortName;)">
 <!ENTITY Ctr_menubarnofog	"Αφαίρεση χρώματος/ομίχλης φόντου (Windows AeroGlass/8)">
 
 <!ENTITY Ctr_aerocolors		"Μπλε χρώματα «Aero» για βασικές εργαλειοθήκες και καρτέλες">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prevent 'Developer Theme' from being enabled">
 
 <!ENTITY Ctr_experttweaks	"Προηγμένες">
-<!ENTITY Ctr_fx33layers		"Ο Firefox 33+ εισήγαγε «νέα χαρακτηριστικά απόδοσης», τρεχόντως υπεύθυνα για το «κρέμασμα καρτελών» σε ορισμένα συστήματα. Αποεπιλέγοντας αυτή την προτίμηση επιλύεται αυτό το ζήτημα.">
-<!ENTITY Ctr_fx34search		"Ο Firefox 34+ εισήγαγε μία «νέα διεπαφή αναζήτησης». Αποεπιλέγοντας αυτή την προτίμηση επαναφέρεται η προηγούμενη διεπαφή.">
-<!ENTITY Ctr_fx34loop		"Ο Firefox 34+ εισήγαγε δυνατότητες «κλήσης και συνομιλίας». Αποεπιλέγοντας αυτή την προτίμηση αφαιρούνται αυτές οι δυνατότητες.">
-<!ENTITY Ctr_fx35devtheme	"Ο Firefox 35+ εισήγαγε ένα νέο «Θέμα δημιουργού». Αποεπιλέγοντας αυτές τις προτιμήσεις απενεργοποιούνται το «Θέμα δημιουργού» και το κουμπί του στη λειτουργία προσαρμογής.">
-<!ENTITY Ctr_fx36prefs		"Ο Firefox 36+ εισήγαγε προβολή επιλογών σε καρτέλα. Αποεπιλέγοντας αυτή την προτίμηση επαναφέρεται το παλιό παράθυρο επιλογών.">
+<!ENTITY Ctr_fx33layers		"Ο &brandShortName; 33+ εισήγαγε «νέα χαρακτηριστικά απόδοσης», τρεχόντως υπεύθυνα για το «κρέμασμα καρτελών» σε ορισμένα συστήματα. Αποεπιλέγοντας αυτή την προτίμηση επιλύεται αυτό το ζήτημα.">
+<!ENTITY Ctr_fx34search		"Ο &brandShortName; 34+ εισήγαγε μία «νέα διεπαφή αναζήτησης». Αποεπιλέγοντας αυτή την προτίμηση επαναφέρεται η προηγούμενη διεπαφή.">
+<!ENTITY Ctr_fx34loop		"Ο &brandShortName; 34+ εισήγαγε δυνατότητες «κλήσης και συνομιλίας». Αποεπιλέγοντας αυτή την προτίμηση αφαιρούνται αυτές οι δυνατότητες.">
+<!ENTITY Ctr_fx35devtheme	"Ο &brandShortName; 35+ εισήγαγε ένα νέο «Θέμα δημιουργού». Αποεπιλέγοντας αυτές τις προτιμήσεις απενεργοποιούνται το «Θέμα δημιουργού» και το κουμπί του στη λειτουργία προσαρμογής.">
+<!ENTITY Ctr_fx36prefs		"Ο &brandShortName; 36+ εισήγαγε προβολή επιλογών σε καρτέλα. Αποεπιλέγοντας αυτή την προτίμηση επαναφέρεται το παλιό παράθυρο επιλογών.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Ρυθμίσεις">
 <!ENTITY Ctr_pw_set_reset	"Επαναφορά προεπιλογών">
 <!ENTITY Ctr_pw_set_predef	"Προκαθορισμένες κλασικές">
-<!ENTITY Ctr_pw_set_preaus	"Προκαθορισμένες Firefox">
+<!ENTITY Ctr_pw_set_preaus	"Προκαθορισμένες &brandShortName;">
 <!ENTITY Ctr_pw_set_export	"Εξαγωγή προτιμήσεων">
 <!ENTITY Ctr_pw_set_import	"Εισαγωγή προτιμήσεων">
 
 <!ENTITY Ctr_special_font	"Οι ρυθμίσεις χρώματος φόντου είναι για το προεπιλεγμένο θέμα μόνο!">
 <!ENTITY Ctr_special_info	"Ορισμένες επιλογές ενδέχεται να μην προσφέρουν ορατές αλλαγές σε όλες τις περιπτώσεις">
-<!ENTITY Ctr_special_info2	"Οι ρυθμίσεις έχουν σχεδιαστεί για το προεπιλεγμένο θέμα του Firefox και ενδέχεται να μη λειτουργούν με όλα τα θέματα τρίτων!">
+<!ENTITY Ctr_special_info2	"Οι ρυθμίσεις έχουν σχεδιαστεί για το προεπιλεγμένο θέμα του &brandShortName; και ενδέχεται να μη λειτουργούν με όλα τα θέματα τρίτων!">
 <!ENTITY Ctr_support		"Φόρουμ υποστήριξης">
 <!ENTITY Ctr_newversion		"Νέα έκδοση;">
 

--- a/xpi/locale/en-US/options.dtd
+++ b/xpi/locale/en-US/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Add-on Bar">
@@ -25,7 +35,7 @@
 <!ENTITY Ctr_tabcolors_t	"Tab colors &amp; text">
 
 <!ENTITY Ctr_tabs			"Tabs">
-<!ENTITY Ctr_tabs0			"Curved tabs (Firefox default)">
+<!ENTITY Ctr_tabs0			"Curved tabs (&brandShortName; default)">
 <!ENTITY Ctr_tabs1			"Squared tabs (classic)">
 <!ENTITY Ctr_tabs1m			"Squared tabs (australized)">
 <!ENTITY Ctr_tabs2			"Curved tabs (alternative)">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Tabs not on top (v2) --- [tabsontop=false] attribute">
 <!ENTITY Ctr_tabsontopW1	"v2 is for some add-ons and complete themes only!">
 <!ENTITY Ctr_tabsontopI1	"Attribute [tabsontop=true/false] gets added to">
-<!ENTITY Ctr_tabsintitlebar	"Firefox titlebar (about:config preference)">
+<!ENTITY Ctr_tabsintitlebar	"&brandShortName; titlebar (about:config preference)">
 <!ENTITY Ctr_tabwidthdef	"(default)">
 <!ENTITY Ctr_tabwidthcla	"(classic)">
 <!ENTITY Ctr_tabminheight	"Height:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Button disabled">
 <!ENTITY Ctr_appbutton1		"Button on toolbar">
 <!ENTITY Ctr_appbutton1wt	"Button on toolbar (text only)">
-<!ENTITY Ctr_appbutton2		"Button on [Firefox] titlebar">
-<!ENTITY Ctr_appbutton2h	"Button on [Firefox] titlebar (hidden)">
-<!ENTITY Ctr_appbutton2io	"Button on [Firefox] titlebar (icon only)">
+<!ENTITY Ctr_appbutton2		"Button on [&brandShortName;] titlebar">
+<!ENTITY Ctr_appbutton2h	"Button on [&brandShortName;] titlebar (hidden)">
+<!ENTITY Ctr_appbutton2io	"Button on [&brandShortName;] titlebar (icon only)">
 <!ENTITY Ctr_paneluibtweak	"Orange panel menu button on tabs toolbar">
 <!ENTITY Ctr_appbuttonc_o	"Orange button color (default)">
 <!ENTITY Ctr_appbuttonc_a	"Blue button color (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"White button color">
 <!ENTITY Ctr_appbuttonc_cu	"Custom button color">
 <!ENTITY Ctr_appbuttonI1	"Restart recommended">
-<!ENTITY Ctr_appbuttonI1e	"Not visible on Windows OS titlebar, only on Firefox titlebar!">
+<!ENTITY Ctr_appbuttonI1e	"Not visible on Windows OS titlebar, only on &brandShortName; titlebar!">
 <!ENTITY Ctr_appbuttonI2	"Button colors are only visible on titlebar and tabs toolbar!">
 <!ENTITY Ctr_alttbappb		"Alternative icons without dropmarker">
 <!ENTITY Ctr_appbutmhi		"Higher position (if on tabs toolbar)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Panel menu popup: hide button labels">
 <!ENTITY Ctr_menupopupscr	"Menupopups: show scrollbars instead of scroll arrows">
 
-<!ENTITY Ctr_fxmockup		"Firefox Mockup">
+<!ENTITY Ctr_fxmockup		"&brandShortName; Mockup">
 <!ENTITY Ctr_tabmokcolor	"White color for tab buttons (close, new, groups, list all)">
 <!ENTITY Ctr_tabmokcolor2	"White color and dark shadow for text on non-active tabs">
 <!ENTITY Ctr_tabmokcolor3	"White color for tab separators">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Additional Toolbars">
 <!ENTITY Ctr_extrabar0		"Additional Toolbar(s)">
 <!ENTITY Ctr_extrabar1		"Additional Toolbar">
-<!ENTITY Ctr_extrabarinfo	"Switching between 'tabs on top' and 'tabs not on top' modes randomly alters additional toolbars order. Firefox has to be restarted to solve this issue.">
+<!ENTITY Ctr_extrabarinfo	"Switching between 'tabs on top' and 'tabs not on top' modes randomly alters additional toolbars order. &brandShortName; has to be restarted to solve this issue.">
 
 <!ENTITY Ctr_invicons		"Inverted icons">
 <!ENTITY Ctr_menubar		"Menubar">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"In maximized mode (tabs on top)">
 
 <!ENTITY Ctr_altmenubar		"Add background color (OS titlebar)">
-<!ENTITY Ctr_altmenubarpos	"Alternative position (below Firefox titlebar)">
+<!ENTITY Ctr_altmenubarpos	"Alternative position (below &brandShortName; titlebar)">
 <!ENTITY Ctr_menubarnofog	"Remove background color/fog (Windows AeroGlass/8)">
 
 <!ENTITY Ctr_aerocolors		"Blue Aero colors for toolbars (and tabs)">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prevent 'Developer Theme' from being enabled">
 
 <!ENTITY Ctr_experttweaks	"Advanced">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ introduced 'new render features' currently responsible for 'hanging tabs' on some systems. Unchecking this preference resolves this issue.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ introduced a 'new seach ui'. Unchecking this preference returns the 'old seach ui'.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ introduced 'calling and conversation' features. Unchecking this preference removes them.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ introduced 'new render features' currently responsible for 'hanging tabs' on some systems. Unchecking this preference resolves this issue.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ introduced a 'new seach ui'. Unchecking this preference returns the 'old seach ui'.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ introduced 'calling and conversation' features. Unchecking this preference removes them.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Settings">
 <!ENTITY Ctr_pw_set_reset	"Restore defaults">
 <!ENTITY Ctr_pw_set_predef	"Classic preset">
-<!ENTITY Ctr_pw_set_preaus	"Firefox preset">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; preset">
 <!ENTITY Ctr_pw_set_export	"Export preferences">
 <!ENTITY Ctr_pw_set_import	"Import preferences">
 
 <!ENTITY Ctr_special_font	"Background color settings are for default theme only!">
 <!ENTITY Ctr_special_info	"Some options may not offer visible changes in all cases">
-<!ENTITY Ctr_special_info2	"Settings are made for Firefox default theme and may not work with all third party themes!">
+<!ENTITY Ctr_special_info2	"Settings are made for &brandShortName; default theme and may not work with all third party themes!">
 <!ENTITY Ctr_support		"Support Forum">
 <!ENTITY Ctr_newversion		"New version?">
 

--- a/xpi/locale/es/options.dtd
+++ b/xpi/locale/es/options.dtd
@@ -1,4 +1,14 @@
-﻿<!ENTITY Ctr_title			"Classic Theme Restorer">
+﻿<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
+<!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Barra de complementos">
 <!ENTITY Ctr_statusbar		"Barra de estado">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Indicador de actividad">
 <!ENTITY Ctr_sidebarbutton	"Barra lateral">
 <!ENTITY Ctr_windowcontrols	"Min/max/cerrar (Pantalla completa)">
-<!ENTITY Ctr_rr				"¡Requiere reiniciar Firefox!">
+<!ENTITY Ctr_rr				"¡Requiere reiniciar &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"Botones">
 <!ENTITY Ctr_cuibutnormal	"Normal">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Botón deshabilitado">
 <!ENTITY Ctr_appbutton1		"Botón en la barra de herramientas">
 <!ENTITY Ctr_appbutton1wt	"Botón en la barra de herramientas (sólo texto)">
-<!ENTITY Ctr_appbutton2		"Botón en la barra de título [de Firefox]">
-<!ENTITY Ctr_appbutton2h	"Botón en la barra de título [de Firefox] (oculto)">
-<!ENTITY Ctr_appbutton2io	"Botón en la barra de título [de Firefox] (sólo icono)">
+<!ENTITY Ctr_appbutton2		"Botón en la barra de título [de &brandShortName;]">
+<!ENTITY Ctr_appbutton2h	"Botón en la barra de título [de &brandShortName;] (oculto)">
+<!ENTITY Ctr_appbutton2io	"Botón en la barra de título [de &brandShortName;] (sólo icono)">
 <!ENTITY Ctr_paneluibtweak	"Botón de menú de panel naranja en la barra de pestañas">
 <!ENTITY Ctr_appbuttonc_o	"Color de botón naranja (predeterminado)">
 <!ENTITY Ctr_appbuttonc_a	"Color de botón azul (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"Color de botón blanco">
 <!ENTITY Ctr_appbuttonc_cu	"Color de botón personalizado">
 <!ENTITY Ctr_appbuttonI1	"Se recomienda reiniciar">
-<!ENTITY Ctr_appbuttonI1e	"¡No es visible en la barra de título de SO de Windows, sólo en la barra de título de Firefox!">
+<!ENTITY Ctr_appbuttonI1e	"¡No es visible en la barra de título de SO de Windows, sólo en la barra de título de &brandShortName;!">
 <!ENTITY Ctr_appbuttonI2	"¡Los colores del botón sólo son visibles en la barra de título y la barra de pestañas!">
 <!ENTITY Ctr_alttbappb		"Iconos alternativos sin flecha">
 <!ENTITY Ctr_appbutmhi		"Posición más alta (si está en la barra de pestañas)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Menú de panel emergente: Ocultar etiquetas de los botones">
 <!ENTITY Ctr_menupopupscr	"Menús emergentes: Mostrar barras de desplazamiento en lugar de flechas">
 
-<!ENTITY Ctr_fxmockup		"Prototipo (mockup) de Firefox">
+<!ENTITY Ctr_fxmockup		"Prototipo (mockup) de &brandShortName;">
 <!ENTITY Ctr_tabmokcolor	"Color blanco para botones de pestaña (cerrar, nueva, grupos, listar todas)">
 <!ENTITY Ctr_tabmokcolor2	"Color blanco y sombreado oscuro para el texto en pestañas no activas">
 <!ENTITY Ctr_tabmokcolor3	"Color blanco para separadores de pestañas">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Barras de herramientas adicionales">
 <!ENTITY Ctr_extrabar0		"Barra(s) de herramientas adicional(es)">
 <!ENTITY Ctr_extrabar1		"Barra de herramientas adicional">
-<!ENTITY Ctr_extrabarinfo	"Cambiar entre los modos 'tabs on top' (pestañas arriba) y 'tabs not on top' (pestañas no arriba) aleatoriamente, altera el orden de las barras de herramientas adicionales. Firefox ha de reiniciarse para resolver el problema.">
+<!ENTITY Ctr_extrabarinfo	"Cambiar entre los modos 'tabs on top' (pestañas arriba) y 'tabs not on top' (pestañas no arriba) aleatoriamente, altera el orden de las barras de herramientas adicionales. &brandShortName; ha de reiniciarse para resolver el problema.">
 
 <!ENTITY Ctr_invicons		"Iconos invertidos">
 <!ENTITY Ctr_menubar		"Barra de menús">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"En modo maximizado (pestañas arriba)">
 
 <!ENTITY Ctr_altmenubar		"Añadir color de fondo (barra de título del SO)">
-<!ENTITY Ctr_altmenubarpos	"Posición alternativa (debajo de la barra de título de Firefox)">
+<!ENTITY Ctr_altmenubarpos	"Posición alternativa (debajo de la barra de título de &brandShortName;)">
 <!ENTITY Ctr_menubarnofog	"Eliminar color de fondo/niebla (Windows Aeroglass/8)">
 
 <!ENTITY Ctr_aerocolors		"Colores azul aero (celeste) para las barras de herramientas principales y pestañas">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prevenir que se habilite el 'tema de decoración de desarrollador'">
 
 <!ENTITY Ctr_experttweaks	"Avanzadas">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ introdujo 'nuevas características de renderizado' responsables en la actualidad de 'colgar pestañas' en algunos sistemas. Desmarcar esta preferencia resuelve el problema.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ introdujo una 'nueva interfaz de usuario de búsqueda'. Desmarcando esta preferencia vuelve a la 'antigua interfaz de usuario de búsqueda'.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ introdujo características de 'llamada y conversación'. Desmarcar esto las retira.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ introdujo un nuevo 'tema de decoración de desarrollador'. Desmarcar estas preferencias deshabilita el 'tema de desarrollador' y su botón en el modo Personalizar.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ introdujo las Opciones (about:preferences) en una pestaña. Desmarcar esta preferencia restaura la antigua ventana de Opciones.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ introdujo 'nuevas características de renderizado' responsables en la actualidad de 'colgar pestañas' en algunos sistemas. Desmarcar esta preferencia resuelve el problema.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ introdujo una 'nueva interfaz de usuario de búsqueda'. Desmarcando esta preferencia vuelve a la 'antigua interfaz de usuario de búsqueda'.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ introdujo características de 'llamada y conversación'. Desmarcar esto las retira.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ introdujo un nuevo 'tema de decoración de desarrollador'. Desmarcar estas preferencias deshabilita el 'tema de desarrollador' y su botón en el modo Personalizar.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ introdujo las Opciones (about:preferences) en una pestaña. Desmarcar esta preferencia restaura la antigua ventana de Opciones.">
 <!ENTITY Ctr_e_omtc			"OMTC / problema de cuelgue de pestañas">
 <!ENTITY Ctr_e_searchui		"Aspecto de la búsqueda">
 <!ENTITY Ctr_e_loop			"Llamada y conversación">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Configuración">
 <!ENTITY Ctr_pw_set_reset	"Restaurar valores predeterminados">
 <!ENTITY Ctr_pw_set_predef	"Preajuste clásico">
-<!ENTITY Ctr_pw_set_preaus	"Preajuste de Firefox">
+<!ENTITY Ctr_pw_set_preaus	"Preajuste de &brandShortName;">
 <!ENTITY Ctr_pw_set_export	"Exportar preferencias">
 <!ENTITY Ctr_pw_set_import	"Importar preferencias">
 
 <!ENTITY Ctr_special_font	"¡Las configuraciones de color de fondo son sólo para el tema de decoración predeterminado!">
 <!ENTITY Ctr_special_info	"¡Algunas opciones podrían no ofrecer cambios visuales en todos los casos!">
-<!ENTITY Ctr_special_info2	"¡Las configuraciones se realizan para el tema de decoración predeterminado de Firefox, y puede que no funcionen con todos los temas de terceros!">
+<!ENTITY Ctr_special_info2	"¡Las configuraciones se realizan para el tema de decoración predeterminado de &brandShortName;, y puede que no funcionen con todos los temas de terceros!">
 <!ENTITY Ctr_support		"Foro de soporte">
 <!ENTITY Ctr_newversion		"¿Nueva versión?">
 

--- a/xpi/locale/fr/options.dtd
+++ b/xpi/locale/fr/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Barre des modules">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Indicateur d'activité">
 <!ENTITY Ctr_sidebarbutton	"Panneau latéral">
 <!ENTITY Ctr_windowcontrols	"Réduire/Restaurer/Fermer (Plein écran)">
-<!ENTITY Ctr_rr				"Redémarrer Firefox!">
+<!ENTITY Ctr_rr				"Redémarrer &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"Boutons">
 <!ENTITY Ctr_cuibutnormal	"Taille normale">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Onglets position basse (v2) --- réglage [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"v2 is for some add-ons and complete themes only!">
 <!ENTITY Ctr_tabsontopI1	"L'attribut [tabsontop=true/false] est assigné à">
-<!ENTITY Ctr_tabsintitlebar	"Barre de titre Firefox (about:config)">
+<!ENTITY Ctr_tabsintitlebar	"Barre de titre &brandShortName; (about:config)">
 <!ENTITY Ctr_tabwidthdef	"(défaut)">
 <!ENTITY Ctr_tabwidthcla	"(classique)">
 <!ENTITY Ctr_tabminheight	"Hauteur :">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Bouton désactivé">
 <!ENTITY Ctr_appbutton1		"Bouton sur une barre d'outils">
 <!ENTITY Ctr_appbutton1wt	"Bouton sur une barre d'outils (texte seul)">
-<!ENTITY Ctr_appbutton2		"Bouton sur la barre de titre [Firefox]">
-<!ENTITY Ctr_appbutton2h	"Bouton sur la barre de titre [Firefox] (hidden)">
-<!ENTITY Ctr_appbutton2io	"Bouton sur la barre de titre [Firefox] (icône seule)">
+<!ENTITY Ctr_appbutton2		"Bouton sur la barre de titre [&brandShortName;]">
+<!ENTITY Ctr_appbutton2h	"Bouton sur la barre de titre [&brandShortName;] (hidden)">
+<!ENTITY Ctr_appbutton2io	"Bouton sur la barre de titre [&brandShortName;] (icône seule)">
 <!ENTITY Ctr_paneluibtweak	"Bouton orange sur la barre d'onglets">
 <!ENTITY Ctr_appbuttonc_o	"Bouton orange (par défaut)">
 <!ENTITY Ctr_appbuttonc_a	"Bouton bleu (Aurora)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Panneau menu : icônes seules">
 <!ENTITY Ctr_menupopupscr	"Menus pop-up : afficher des ascenseurs au lieu des flèches de défilement">
 
-<!ENTITY Ctr_fxmockup		"Firefox Mockup">
+<!ENTITY Ctr_fxmockup		"&brandShortName; Mockup">
 <!ENTITY Ctr_tabmokcolor	"Boutons des onglets de couleur blanche (fermer, nouveau, groupes, tout lister)">
 <!ENTITY Ctr_tabmokcolor2	"Texte des onglets de couleur blanche + ombre noire pour les onglets non actifs">
 <!ENTITY Ctr_tabmokcolor3	"Séparateurs de couleur blanche sur la barre d'onglets">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Barres d'outils supplémentaires">
 <!ENTITY Ctr_extrabar0		"Barre(s) d'outil(s) supplémentaire(s)">
 <!ENTITY Ctr_extrabar1		"Barre d'outils supplémentaire">
-<!ENTITY Ctr_extrabarinfo	"En basculant entre 'onglets en haut' et 'onglets position basse' l'ordre des barres d'outils peut de temps en temps être altéré. Firefox doit être redémarré pour remédier à ce problème.">
+<!ENTITY Ctr_extrabarinfo	"En basculant entre 'onglets en haut' et 'onglets position basse' l'ordre des barres d'outils peut de temps en temps être altéré. &brandShortName; doit être redémarré pour remédier à ce problème.">
 
 <!ENTITY Ctr_invicons		"Icônes inversées">
 <!ENTITY Ctr_menubar		"Barre de menus">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"In maximized mode (tabs on top)">
 
 <!ENTITY Ctr_altmenubar		"Ajouter un arrière-plan (barre de titre de l'OS visible)">
-<!ENTITY Ctr_altmenubarpos	"Position alternative (sous la barre de titre Firefox)">
+<!ENTITY Ctr_altmenubarpos	"Position alternative (sous la barre de titre &brandShortName;)">
 <!ENTITY Ctr_menubarnofog	"Enlever l'effet de flou/l'arrière-plan des éléments (Windows AeroGlass / Win8)">
 
 <!ENTITY Ctr_aerocolors		"Blue Aero colors for main toolbars and tabs">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prevent 'Developer Theme' from being enabled">
 
 <!ENTITY Ctr_experttweaks	"Expert">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ introduit de nouvelles possibilités de rendu responsables actuellement de bugs avec les onglets sur certains systèmes (pas de réaction, onglets gelés). Ce problème est résolu en décochant cette option.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ introduit une nouvelle barre de recherche. Si cette option est décochée, l'ancienne barre de recherche est activée.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ introduit la possibilité d'inviter quelqu'un à discuter. Cette possibilité est desactivée en décochant cette option.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ introduit de nouvelles possibilités de rendu responsables actuellement de bugs avec les onglets sur certains systèmes (pas de réaction, onglets gelés). Ce problème est résolu en décochant cette option.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ introduit une nouvelle barre de recherche. Si cette option est décochée, l'ancienne barre de recherche est activée.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ introduit la possibilité d'inviter quelqu'un à discuter. Cette possibilité est desactivée en décochant cette option.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,7 +277,7 @@
 <!ENTITY Ctr_pw_settings	"Réglages">
 <!ENTITY Ctr_pw_set_reset	"Restaurer les réglages par défaut">
 <!ENTITY Ctr_pw_set_predef	"Préréglage classique">
-<!ENTITY Ctr_pw_set_preaus	"Préréglage Firefox">
+<!ENTITY Ctr_pw_set_preaus	"Préréglage &brandShortName;">
 <!ENTITY Ctr_pw_set_export	"Exporter les préférences">
 <!ENTITY Ctr_pw_set_import	"Importer les préférences">
 

--- a/xpi/locale/hsb/options.dtd
+++ b/xpi/locale/hsb/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Lajsta přidatkow">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Wozjewjenje aktiwity">
 <!ENTITY Ctr_sidebarbutton	"Bočnica">
 <!ENTITY Ctr_windowcontrols	"Min./maks./začinić (połna wobrazowka)">
-<!ENTITY Ctr_rr				"Startujće Firefox znowa!">
+<!ENTITY Ctr_rr				"Startujće &brandShortName; znowa!">
 
 <!ENTITY Ctr_cuibuttons		"Tłóčatka">
 <!ENTITY Ctr_cuibutnormal	"Normalny">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Rajtarki nic horjeka (v2) --- stajće [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"v2 je jenož za někotre přidatki a dospołne drasty!">
 <!ENTITY Ctr_tabsontopI1	"Přidawa atribut [tabsontop=true/false] na">
-<!ENTITY Ctr_tabsintitlebar	"Titulna lajsta Firefox (about:config)">
+<!ENTITY Ctr_tabsintitlebar	"Titulna lajsta &brandShortName; (about:config)">
 <!ENTITY Ctr_tabwidthdef	"(standard)">
 <!ENTITY Ctr_tabwidthcla	"(klasiski)">
 <!ENTITY Ctr_tabminheight	"Wysokosć:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Tłóčatko znjemóžnjeny">
 <!ENTITY Ctr_appbutton1		"Tłóčatko na symbolowej lajsće">
 <!ENTITY Ctr_appbutton1wt	"Tłóčatko na symbolowej lajsće (jenož tekst)">
-<!ENTITY Ctr_appbutton2		"Tłóčatko na titulnej lajsće [Firefox]">
-<!ENTITY Ctr_appbutton2h	"Tłóčatko na titulnej lajsće [Firefox] (schowane)">
-<!ENTITY Ctr_appbutton2io	"Tłóčatko na titulnej lajsće [Firefox] (jenož symbol)">
+<!ENTITY Ctr_appbutton2		"Tłóčatko na titulnej lajsće [&brandShortName;]">
+<!ENTITY Ctr_appbutton2h	"Tłóčatko na titulnej lajsće [&brandShortName;] (schowane)">
+<!ENTITY Ctr_appbutton2io	"Tłóčatko na titulnej lajsće [&brandShortName;] (jenož symbol)">
 <!ENTITY Ctr_paneluibtweak	"Oranžowe menijowe tłóčatko na rajtarkowej lajsće">
 <!ENTITY Ctr_appbuttonc_o	"Tłóčatkowa barba: Oranžowy (standard)">
 <!ENTITY Ctr_appbuttonc_a	"Tłóčatkowa barba: Módry (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"Tłóčatkowa barba: Běły">
 <!ENTITY Ctr_appbuttonc_cu	"Swójska tłóčatkowa barba">
 <!ENTITY Ctr_appbuttonI1	"Nowy start doporučeny">
-<!ENTITY Ctr_appbuttonI1e	"Njeje widźomny w titulnej lajsće Windows, jenož w titulnej lajsće Firefox!">
+<!ENTITY Ctr_appbuttonI1e	"Njeje widźomny w titulnej lajsće Windows, jenož w titulnej lajsće &brandShortName;!">
 <!ENTITY Ctr_appbuttonI2	"Tłóčatkowe barby su jenož widźomne na titulnej lajsće a rajtarkowej lajsće!">
 <!ENTITY Ctr_alttbappb		"Alternatiwne symbole">
 <!ENTITY Ctr_appbutmhi		"Wyša pozicija (jeli je na rajtarkowej lajsće)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Pólny meni: Tekst tłóčatkow schować">
 <!ENTITY Ctr_menupopupscr	"Wuskakowace menije: suwanske lajsty město suwanskich šipkow pokazać">
 
-<!ENTITY Ctr_fxmockup		"Naćisk Firefox">
+<!ENTITY Ctr_fxmockup		"Naćisk &brandShortName;">
 <!ENTITY Ctr_tabmokcolor	"Běła barba za rajtarkowe tłóčatka (začinić, nowy, skupiny, wšě nalistować)">
 <!ENTITY Ctr_tabmokcolor2	"Běła barba a ćmowy sćin za tekst na njeaktiwnych rajtarkach">
 <!ENTITY Ctr_tabmokcolor3	"Běła barba za rajtarkowe dźělatka">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Přidatne symbolowe lajsty">
 <!ENTITY Ctr_extrabar0		"Přidatne symbolowe lajsty">
 <!ENTITY Ctr_extrabar1		"Přidatna symbolowa lajsta">
-<!ENTITY Ctr_extrabarinfo	"Přešaltowanje mjez 'rajtarki horjeka' a 'rajtarki deleka' měnja připadnje porjad přidatnych symbolowych lajstow. Firefox dyrbi so znowa startować, zo by so tutón problem rozrisał.">
+<!ENTITY Ctr_extrabarinfo	"Přešaltowanje mjez 'rajtarki horjeka' a 'rajtarki deleka' měnja připadnje porjad přidatnych symbolowych lajstow. &brandShortName; dyrbi so znowa startować, zo by so tutón problem rozrisał.">
 
 <!ENTITY Ctr_invicons		"Inwertowane symbole">
 <!ENTITY Ctr_menubar		"Menijowa lajsta">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"W maksiměrowanym napohledźe (rajtarki horjeka)">
 
 <!ENTITY Ctr_altmenubar		"Pozadkowu barbu přidać (titulna lajsta dźěłoweho systema)">
-<!ENTITY Ctr_altmenubarpos	"Alternatiwna pozicijia (pod titulnej lajstu Firefox)">
+<!ENTITY Ctr_altmenubarpos	"Alternatiwna pozicijia (pod titulnej lajstu &brandShortName;)">
 <!ENTITY Ctr_menubarnofog	"Pozadkowu barbu/młu wotstronić (Windows AeroGlass / Win8)">
 
 <!ENTITY Ctr_aerocolors		"Barby 'Blue Aero' za hłowne lajsty a rajtarki">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Zmóžnjenju 'wuwiwarskeje drasty' zadźěwać">
 
 <!ENTITY Ctr_experttweaks	"Rozšěrjene">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ je 'nowe rysowanske funkcije' zawjedł, kotrež su tuchwilu zamołwite za 'njereagowace rajtarki' na někotrych systemach. Znjemóžnjenje tutoho nastajenja tutón problem rozrisa.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ je 'nowy pytanski powjerch' zawjedł. Znjemóžnjenje tutoho nastajenja 'stary pytanski powjerch' wobnowi.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ je 'zawołanske a konwersaciske' funkcije zawjedł. Znjemóžnjenje tutoho nastajenja je wotstroni.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ je nowu 'wuwiwarsku drastu' zawjedł. Znjemóžnjenje tutych nastajenjow znjemóžni 'wuwiwarsku drastu' a jeje tłóčatko w přiměrjenskim modusu.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ je 'nastajenja w rajtarku' zawjedł. Znjemóžnjenje tutoho nastajenja stare wokno nastajenjow wobnowi.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ je 'nowe rysowanske funkcije' zawjedł, kotrež su tuchwilu zamołwite za 'njereagowace rajtarki' na někotrych systemach. Znjemóžnjenje tutoho nastajenja tutón problem rozrisa.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ je 'nowy pytanski powjerch' zawjedł. Znjemóžnjenje tutoho nastajenja 'stary pytanski powjerch' wobnowi.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ je 'zawołanske a konwersaciske' funkcije zawjedł. Znjemóžnjenje tutoho nastajenja je wotstroni.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ je nowu 'wuwiwarsku drastu' zawjedł. Znjemóžnjenje tutych nastajenjow znjemóžni 'wuwiwarsku drastu' a jeje tłóčatko w přiměrjenskim modusu.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ je 'nastajenja w rajtarku' zawjedł. Znjemóžnjenje tutoho nastajenja stare wokno nastajenjow wobnowi.">
 <!ENTITY Ctr_e_omtc			"OMTC / problem z wisacymi rajtarkami">
 <!ENTITY Ctr_e_searchui		"Pytanski powjerch">
 <!ENTITY Ctr_e_loop			"Zawołanje a konwersacija">
@@ -267,7 +277,7 @@
 <!ENTITY Ctr_pw_settings	"Nastajenja">
 <!ENTITY Ctr_pw_set_reset	"Standard wobnowić">
 <!ENTITY Ctr_pw_set_predef	"Klasiske standardne hódnoty">
-<!ENTITY Ctr_pw_set_preaus	"Standard Firefox">
+<!ENTITY Ctr_pw_set_preaus	"Standard &brandShortName;">
 <!ENTITY Ctr_pw_set_export	"Nastajenja eksportować">
 <!ENTITY Ctr_pw_set_import	"Nastajenja importować">
 

--- a/xpi/locale/it/options.dtd
+++ b/xpi/locale/it/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title 			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Barra dei componenti aggiuntivi">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Indicatore di attività">
 <!ENTITY Ctr_sidebarbutton	"Barra laterale">
 <!ENTITY Ctr_windowcontrols	"Min/max/chiudi (A tutto schermo)">
-<!ENTITY Ctr_rr				"Riavviare Firefox!">
+<!ENTITY Ctr_rr				"Riavviare &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"Pulsanti">
 <!ENTITY Ctr_cuibutnormal	"Normali">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Barre degli strumenti aggiuntive">
 <!ENTITY Ctr_extrabar0		"Barre degli strumenti aggiuntive">
 <!ENTITY Ctr_extrabar1		"Barra degli strumenti aggiuntiva">
-<!ENTITY Ctr_extrabarinfo	"La commutazione tra la modalità 'schede in alto' e 'schede in basso' altera in modo casuale l'ordine delle barre degli strumenti aggiuntive. Si deve riavviare Firefox per risolvere questo problema.">
+<!ENTITY Ctr_extrabarinfo	"La commutazione tra la modalità 'schede in alto' e 'schede in basso' altera in modo casuale l'ordine delle barre degli strumenti aggiuntive. Si deve riavviare &brandShortName; per risolvere questo problema.">
 
 <!ENTITY Ctr_invicons		"Icone invertite">
 <!ENTITY Ctr_menubar		"Barra dei menu">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Impedisci l'attivazione del 'Developer Theme'">
 
 <!ENTITY Ctr_experttweaks	"Avanzate">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ ha introdotto nuove funzioni di rendering che sono responsabili del blocco delle schede in alcuni sistemi. Deselezionare questa opzione per risolvere il problema.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ ha introdotto una nuova barra di ricerca. Deselezionare questa opzione per ripristinare la barra precedente.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ ha introdotto le funzioni di chiamata e conversazione. Deselezionare questa opzione per rimuoverle.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ ha introdotto un nuovo 'developer theme'. Deselezionare questa opzione per disattivare il 'developer theme' e il suo pulsante nella modalità di personalizzazione.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ ha introdotto le preferenze in una scheda. Deselezionare questa opzione per ripristinare la finestra delle preferenze classica.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ ha introdotto nuove funzioni di rendering che sono responsabili del blocco delle schede in alcuni sistemi. Deselezionare questa opzione per risolvere il problema.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ ha introdotto una nuova barra di ricerca. Deselezionare questa opzione per ripristinare la barra precedente.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ ha introdotto le funzioni di chiamata e conversazione. Deselezionare questa opzione per rimuoverle.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ ha introdotto un nuovo 'developer theme'. Deselezionare questa opzione per disattivare il 'developer theme' e il suo pulsante nella modalità di personalizzazione.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ ha introdotto le preferenze in una scheda. Deselezionare questa opzione per ripristinare la finestra delle preferenze classica.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,7 +277,7 @@
 <!ENTITY Ctr_pw_settings	"Impostazioni">
 <!ENTITY Ctr_pw_set_reset	"Ripristina predefinite">
 <!ENTITY Ctr_pw_set_predef	"Preset classico">
-<!ENTITY Ctr_pw_set_preaus	"Preset Firefox">
+<!ENTITY Ctr_pw_set_preaus	"Preset &brandShortName;">
 <!ENTITY Ctr_pw_set_export	"Esporta preferenze">
 <!ENTITY Ctr_pw_set_import	"Importa preferenze">
 

--- a/xpi/locale/ja/options.dtd
+++ b/xpi/locale/ja/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"アドオンバー">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Activity Indicator">
 <!ENTITY Ctr_sidebarbutton	"サイドバー">
 <!ENTITY Ctr_windowcontrols	"最小/最大/閉じる (Fullscreen)">
-<!ENTITY Ctr_rr				"要 Firefox 再起動">
+<!ENTITY Ctr_rr				"要 &brandShortName; 再起動">
 
 <!ENTITY Ctr_cuibuttons		"ボタン">
 <!ENTITY Ctr_cuibutnormal	"通常">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"タブを下にする (v2) --- [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"v2 is for some add-ons and complete themes only!">
 <!ENTITY Ctr_tabsontopI1	"以下に属性[tabsontop=true/false]を加える">
-<!ENTITY Ctr_tabsintitlebar	"Firefox タイトルバー (about:config設定)">
+<!ENTITY Ctr_tabsintitlebar	"&brandShortName; タイトルバー (about:config設定)">
 <!ENTITY Ctr_tabwidthdef	"(デフォルト)">
 <!ENTITY Ctr_tabwidthcla	"(クラシック)">
 <!ENTITY Ctr_tabminheight	"高さ:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"ボタンを無効にする">
 <!ENTITY Ctr_appbutton1		"ツールバーに表示">
 <!ENTITY Ctr_appbutton1wt	"ツールバーに表示 (テキストのみ)">
-<!ENTITY Ctr_appbutton2		"Firefox タイトルバーに表示">
-<!ENTITY Ctr_appbutton2h	"Firefox タイトルバーに表示 (hidden)">
-<!ENTITY Ctr_appbutton2io	"Firefox タイトルバーに表示 (アイコンのみ)">
+<!ENTITY Ctr_appbutton2		"&brandShortName; タイトルバーに表示">
+<!ENTITY Ctr_appbutton2h	"&brandShortName; タイトルバーに表示 (hidden)">
+<!ENTITY Ctr_appbutton2io	"&brandShortName; タイトルバーに表示 (アイコンのみ)">
 <!ENTITY Ctr_paneluibtweak	"タブツールバーに橙のパネルメニューボタン">
 <!ENTITY Ctr_appbuttonc_o	"橙色 (デフォルト)">
 <!ENTITY Ctr_appbuttonc_a	"青色 (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"白色">
 <!ENTITY Ctr_appbuttonc_cu	"任意の色">
 <!ENTITY Ctr_appbuttonI1	"再起動を推奨">
-<!ENTITY Ctr_appbuttonI1e	"WindowsのOSタイトルバーには表示されません。Firefoxタイトルバー上のみです。">
+<!ENTITY Ctr_appbuttonI1e	"WindowsのOSタイトルバーには表示されません。&brandShortName;タイトルバー上のみです。">
 <!ENTITY Ctr_appbuttonI2	"ボタン色はタイトルバーとタブツールバーのみに表示されます。">
 <!ENTITY Ctr_alttbappb		"別バージョンのアイコンにする">
 <!ENTITY Ctr_appbutmhi		"高い位置に表示 (タブツールバーに表示した時のみ)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"パネルメニューポップアップ：ボタンのラベルを隠す">
 <!ENTITY Ctr_menupopupscr	"メニューポップアップ: 矢印の代わりにスクロールバーを表示する">
 
-<!ENTITY Ctr_fxmockup		"Firefox モックアップ">
+<!ENTITY Ctr_fxmockup		"&brandShortName; モックアップ">
 <!ENTITY Ctr_tabmokcolor	"タブボタンを白色にする (閉じる、新しいタブを開く、タブグループ、タブを一覧表示)">
 <!ENTITY Ctr_tabmokcolor2	"非アクティブタブを白色の文字にして、灰色の影をつける">
 <!ENTITY Ctr_tabmokcolor3	"タブセパレータを白色にする">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Additional Toolbars">
 <!ENTITY Ctr_extrabar0		"Additional Toolbar(s)">
 <!ENTITY Ctr_extrabar1		"追加のツールバー">
-<!ENTITY Ctr_extrabarinfo	"Switching between 'tabs on top' and 'tabs not on top' modes randomly alters additional toolbars order. Firefox has to be restarted to solve this issue.">
+<!ENTITY Ctr_extrabarinfo	"Switching between 'tabs on top' and 'tabs not on top' modes randomly alters additional toolbars order. &brandShortName; has to be restarted to solve this issue.">
 
 <!ENTITY Ctr_invicons		"反転アイコン">
 <!ENTITY Ctr_menubar		"メニューバー">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"In maximized mode (tabs on top)">
 
 <!ENTITY Ctr_altmenubar		"背景色を加える (OS タイトルバー)">
-<!ENTITY Ctr_altmenubarpos	"別の位置 (Firefoxタイトルバーの下)">
+<!ENTITY Ctr_altmenubarpos	"別の位置 (&brandShortName;タイトルバーの下)">
 <!ENTITY Ctr_menubarnofog	"背景色とぼかしを取り除く (Windows AeroGlass / Win8)">
 
 <!ENTITY Ctr_aerocolors		"Blue Aero colors for main toolbars and tabs">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prevent 'Developer Theme' from being enabled">
 
 <!ENTITY Ctr_experttweaks	"拡張設定">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ introduced 'new render features' currently responsible for 'hanging tabs' on some systems. Unchecking this preference resolves this issue.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ introduced a 'new seach ui'. Unchecking this preference returns the 'old seach ui'.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ introduced 'calling and conversation' features. Unchecking this preference removes them.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ introduced 'new render features' currently responsible for 'hanging tabs' on some systems. Unchecking this preference resolves this issue.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ introduced a 'new seach ui'. Unchecking this preference returns the 'old seach ui'.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ introduced 'calling and conversation' features. Unchecking this preference removes them.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"設定">
 <!ENTITY Ctr_pw_set_reset	"デフォルトに戻す">
 <!ENTITY Ctr_pw_set_predef	"クラシックプリセット">
-<!ENTITY Ctr_pw_set_preaus	"Firefox preset">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; preset">
 <!ENTITY Ctr_pw_set_export	"設定をエクスポート">
 <!ENTITY Ctr_pw_set_import	"設定をインポート">
 
 <!ENTITY Ctr_special_font	"背景色の設定はデフォルトテーマのみに適用されます。">
 <!ENTITY Ctr_special_info	"一部オプションは特定のケースでのみ動作します。">
-<!ENTITY Ctr_special_info2	"設定はFirefox デフォルトテーマ用に作成されたもので、サードパーティのテーマで動作しないかもしれません。">
+<!ENTITY Ctr_special_info2	"設定は&brandShortName; デフォルトテーマ用に作成されたもので、サードパーティのテーマで動作しないかもしれません。">
 <!ENTITY Ctr_support		"サポートフォーラム (英語)">
 <!ENTITY Ctr_newversion		"新バージョンをチェック">
 

--- a/xpi/locale/pl/options.dtd
+++ b/xpi/locale/pl/options.dtd
@@ -1,4 +1,14 @@
-﻿<!ENTITY Ctr_title			"Classic Theme Restorer">
+﻿<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
+<!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Pasek dodatków">
 <!ENTITY Ctr_statusbar		"Pasek statusu">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Przycisk wyłączony">
 <!ENTITY Ctr_appbutton1		"Przycisk na pasku narzędzi">
 <!ENTITY Ctr_appbutton1wt	"Przycisk na pasku narzędzi (tylko tekst)">
-<!ENTITY Ctr_appbutton2		"Przycisk na pasku narzędzi [Firefox]">
-<!ENTITY Ctr_appbutton2h	"Przycisk na pasku narzędzi [Firefox] (ukryty)">
-<!ENTITY Ctr_appbutton2io	"Przycisk na pasku narzędzi [Firefox] (tylko ikona)">
+<!ENTITY Ctr_appbutton2		"Przycisk na pasku narzędzi [&brandShortName;]">
+<!ENTITY Ctr_appbutton2h	"Przycisk na pasku narzędzi [&brandShortName;] (ukryty)">
+<!ENTITY Ctr_appbutton2io	"Przycisk na pasku narzędzi [&brandShortName;] (tylko ikona)">
 <!ENTITY Ctr_paneluibtweak	"Pomarańczowy przycisk menu panelu na pasku kart">
 <!ENTITY Ctr_appbuttonc_o	"Pomarańczowy kolor przycisku (domyślny)">
 <!ENTITY Ctr_appbuttonc_a	"Błękitny kolor przycisku (Aurora)">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Dodatkowe paski narzędzi">
 <!ENTITY Ctr_extrabar0		"Dodatkowy pasek (dodatkowe paski) narzędzi">
 <!ENTITY Ctr_extrabar1		"Dodatkowy pasek narzędzi">
-<!ENTITY Ctr_extrabarinfo	"Przełączanie pomiędzy trybami 'karty na górze' a 'karty nie na górze' losowo zmienia układ dodatkowych pasków narzędzi. Firefox musi zostać zrestartowany, aby rozwiązać ten problem.">
+<!ENTITY Ctr_extrabarinfo	"Przełączanie pomiędzy trybami 'karty na górze' a 'karty nie na górze' losowo zmienia układ dodatkowych pasków narzędzi. &brandShortName; musi zostać zrestartowany, aby rozwiązać ten problem.">
 
 <!ENTITY Ctr_invicons		"Odwrócone kolory ikon">
 <!ENTITY Ctr_menubar		"Pasek menu">
@@ -253,11 +263,11 @@
 
 
 <!ENTITY Ctr_experttweaks	"Poprawki eksperckie">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ wprowadził 'nowe funkcje renderowania' odpowiedzialne obecnie za 'zawieszanie się kart' w niektórych systemach. Odznaczenie tego ustawienia rozwiązuje ten problem.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ wprowadził 'nowy interfejs wyszukiwania'. Odznaczenie tego ustawienia przywraca 'stary interfejs wyszukiwania'.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ wprowadził funkcje 'dzwonienia i konwersacji'. Odznaczenie tego ustawienia usunie je.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ wprowadził nowy 'motyw dewelopera'. Odznaczenie tych ustawień wyłącza 'motyw dewelopera' oraz jego przycisk w trybie dostosowywania.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ wprowadził opcje w karcie. Odznaczenie tego ustawienia przywraca stare okno opcji.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ wprowadził 'nowe funkcje renderowania' odpowiedzialne obecnie za 'zawieszanie się kart' w niektórych systemach. Odznaczenie tego ustawienia rozwiązuje ten problem.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ wprowadził 'nowy interfejs wyszukiwania'. Odznaczenie tego ustawienia przywraca 'stary interfejs wyszukiwania'.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ wprowadził funkcje 'dzwonienia i konwersacji'. Odznaczenie tego ustawienia usunie je.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ wprowadził nowy 'motyw dewelopera'. Odznaczenie tych ustawień wyłącza 'motyw dewelopera' oraz jego przycisk w trybie dostosowywania.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ wprowadził opcje w karcie. Odznaczenie tego ustawienia przywraca stare okno opcji.">
 <!ENTITY Ctr_e_omtc			"Problem z OMTC/zawieszonymi kartami">
 <!ENTITY Ctr_e_searchui		"Wygląd wyszukiwania">
 <!ENTITY Ctr_e_loop			"Dzwonienie i konwersacja">

--- a/xpi/locale/pt-BR/options.dtd
+++ b/xpi/locale/pt-BR/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Barra de Complementos">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Indicador de Atividade">
 <!ENTITY Ctr_sidebarbutton	"Barra Lateral">
 <!ENTITY Ctr_windowcontrols	"Mínimo/Máximo/Fechar (Tela Cheia)">
-<!ENTITY Ctr_rr				"Reinicie o Firefox!">
+<!ENTITY Ctr_rr				"Reinicie o &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"Botões">
 <!ENTITY Ctr_cuibutnormal	"Normais">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Abas Embaixo (v2) --- Definida [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"v2 é Só para Alguns Complementos e Temas Completos!">
 <!ENTITY Ctr_tabsontopI1	"Adicionar Atributos [tabsontop=true/false] para">
-<!ENTITY Ctr_tabsintitlebar	"Barra de Título do Firefox (about:config)">
+<!ENTITY Ctr_tabsintitlebar	"Barra de Título do &brandShortName; (about:config)">
 <!ENTITY Ctr_tabwidthdef	"(Padrão)">
 <!ENTITY Ctr_tabwidthcla	"(Clássica)">
 <!ENTITY Ctr_tabminheight	"Altura:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Botão Desativado">
 <!ENTITY Ctr_appbutton1		"Botão na Barra de Ferramentas">
 <!ENTITY Ctr_appbutton1wt	"Botão na Barra de Ferramentas (Só o Texto)">
-<!ENTITY Ctr_appbutton2		"Botão na Barra de Título [Firefox]">
-<!ENTITY Ctr_appbutton2h	"Botão na Barra de Título [Firefox] (Oculto)">
-<!ENTITY Ctr_appbutton2io	"Botão na Barra de Título [Firefox] (Só o Ícone)">
+<!ENTITY Ctr_appbutton2		"Botão na Barra de Título [&brandShortName;]">
+<!ENTITY Ctr_appbutton2h	"Botão na Barra de Título [&brandShortName;] (Oculto)">
+<!ENTITY Ctr_appbutton2io	"Botão na Barra de Título [&brandShortName;] (Só o Ícone)">
 <!ENTITY Ctr_paneluibtweak	"Botão do Menu do Painel na Barra de Abas na Cor Laranja">
 <!ENTITY Ctr_appbuttonc_o	"Botão Laranja (Padrão)">
 <!ENTITY Ctr_appbuttonc_a	"Botão Azul (Aurora)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Menu do Painel: Ocultar Rótulos do Botão">
 <!ENTITY Ctr_menupopupscr	"Pop-ups do Menu: Exibir Barras de Rolagem em vez das Setas de Rolagem">
 
-<!ENTITY Ctr_fxmockup		"Modelo do Firefox">
+<!ENTITY Ctr_fxmockup		"Modelo do &brandShortName;">
 <!ENTITY Ctr_tabmokcolor	"Botões da Aba na Cor Branca (Fechar, Nova, Grupos, Listar Tudo)">
 <!ENTITY Ctr_tabmokcolor2	"Texto na Cor Branca e Sombra Escura nas Abas Inativas">
 <!ENTITY Ctr_tabmokcolor3	"Separadores para as Abas na Cor Branca">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Barras de Ferramentas Adicionais">
 <!ENTITY Ctr_extrabar0		"Barra(s) de Ferramenta(s) Adicional(is)">
 <!ENTITY Ctr_extrabar1		"Barra de Ferramentas Adicional">
-<!ENTITY Ctr_extrabarinfo	"Alternar Entre os Modos 'Abas no Topo' e 'Abas Embaixo', Alterará Aleatoriamente a Ordem das Barras de Ferramentas Adicionais. O Firefox Precisa ser Reiniciado para Resolver este Problema.">
+<!ENTITY Ctr_extrabarinfo	"Alternar Entre os Modos 'Abas no Topo' e 'Abas Embaixo', Alterará Aleatoriamente a Ordem das Barras de Ferramentas Adicionais. O &brandShortName; Precisa ser Reiniciado para Resolver este Problema.">
 
 <!ENTITY Ctr_invicons		"Ícones Invertidos">
 <!ENTITY Ctr_menubar		"Barra de Menus">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Evitar Habilitar o 'Tema do Desenvolvedor'">
 
 <!ENTITY Ctr_experttweaks	"Avançado">
-<!ENTITY Ctr_fx33layers		"O Firefox 33+ Introduziu 'Novos Recursos de Renderização', Atualmente Responsáveis por 'Suspender Abas' em Alguns Sistemas. Desmarque esta Opção para Resolver este Problema.">
-<!ENTITY Ctr_fx34search		"O Firefox 34+ Introduziu uma 'Nova Interface de Usuário de Pesquisa'. Desmarque esta Opção para Retornar à 'Antiga Interface de Usuário de Pesquisa'.">
-<!ENTITY Ctr_fx34loop		"O Firefox 34+ Introduziu Recursos de 'Chamada e Conversação'. Desmarque esta Opção para Removê-los.">
-<!ENTITY Ctr_fx35devtheme	"O Firefox 35+ Introduziu um Novo 'Tema do Desenvolvedor'. Desmarque estas Opções para Desabilitar o 'Tema do Desenvolvedor' e o seu Botão em Modo de Personalização.">
-<!ENTITY Ctr_fx36prefs		"O Firefox 36+ Introduziu as Preferências em uma Nova Aba. Desmarque esta Opção para Retornar à Antiga Janela de Preferências.">
+<!ENTITY Ctr_fx33layers		"O &brandShortName; 33+ Introduziu 'Novos Recursos de Renderização', Atualmente Responsáveis por 'Suspender Abas' em Alguns Sistemas. Desmarque esta Opção para Resolver este Problema.">
+<!ENTITY Ctr_fx34search		"O &brandShortName; 34+ Introduziu uma 'Nova Interface de Usuário de Pesquisa'. Desmarque esta Opção para Retornar à 'Antiga Interface de Usuário de Pesquisa'.">
+<!ENTITY Ctr_fx34loop		"O &brandShortName; 34+ Introduziu Recursos de 'Chamada e Conversação'. Desmarque esta Opção para Removê-los.">
+<!ENTITY Ctr_fx35devtheme	"O &brandShortName; 35+ Introduziu um Novo 'Tema do Desenvolvedor'. Desmarque estas Opções para Desabilitar o 'Tema do Desenvolvedor' e o seu Botão em Modo de Personalização.">
+<!ENTITY Ctr_fx36prefs		"O &brandShortName; 36+ Introduziu as Preferências em uma Nova Aba. Desmarque esta Opção para Retornar à Antiga Janela de Preferências.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Configurações">
 <!ENTITY Ctr_pw_set_reset	"Restaurar aos Padrões">
 <!ENTITY Ctr_pw_set_predef	"Pré-configurações Clássicas">
-<!ENTITY Ctr_pw_set_preaus	"Pré-configurações do Firefox">
+<!ENTITY Ctr_pw_set_preaus	"Pré-configurações do &brandShortName;">
 <!ENTITY Ctr_pw_set_export	"Exportar as Preferências">
 <!ENTITY Ctr_pw_set_import	"Importar as Preferências">
 
 <!ENTITY Ctr_special_font	"As Configurações da Cor do Fundo são Só para o Tema Padrão!">
 <!ENTITY Ctr_special_info	"Algumas Opções Podem Oferecer Alterações Visuais Só em Certos Casos!">
-<!ENTITY Ctr_special_info2	"As Configurações são Feitas para o Tema Padrão do Firefox, e Podem Não Funcionar com Temas de Terceiros!">
+<!ENTITY Ctr_special_info2	"As Configurações são Feitas para o Tema Padrão do &brandShortName;, e Podem Não Funcionar com Temas de Terceiros!">
 <!ENTITY Ctr_support		"Forum de Suporte">
 <!ENTITY Ctr_newversion		"Há uma Nova Versão?">
 

--- a/xpi/locale/ru/options.dtd
+++ b/xpi/locale/ru/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Панель дополнений">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Индикатор активности">
 <!ENTITY Ctr_sidebarbutton	"Боковая панель">
 <!ENTITY Ctr_windowcontrols	"Мин/макс/закрыть (Полноэкранный)">
-<!ENTITY Ctr_rr				"Перезапустите Firefox!">
+<!ENTITY Ctr_rr				"Перезапустите &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"Кнопки:">
 <!ENTITY Ctr_cuibutnormal	"Обычные">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Панель меню: спрятать надписи на кнопках">
 <!ENTITY Ctr_menupopupscr	"Всплывающие окна меню: показывать полосы прокрутки вместо стрелки прокрутки">
 
-<!ENTITY Ctr_fxmockup		"Другие настройки для Firefox">
+<!ENTITY Ctr_fxmockup		"Другие настройки для &brandShortName;">
 <!ENTITY Ctr_tabmokcolor	"Белый цвет для кнопок вкладок (закрыть, новая, группы, список всех)">
 <!ENTITY Ctr_tabmokcolor2	"Белый цвет и тёмная тень для текста на неактивной вкладке">
 <!ENTITY Ctr_tabmokcolor3	"Белый цвет для разделителей на панели вкладок">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Дополнительные панели инструментов">
 <!ENTITY Ctr_extrabar0		"Дополнительная панель(и)">
 <!ENTITY Ctr_extrabar1		"Дополнительная панель">
-<!ENTITY Ctr_extrabarinfo	"Переключение между режимами «Вкладки вверху» и «Вкладки не вверху» меняет расположение дополнительных панелей. Чтобы решить эту проблему, Firefox должен быть перезапущен.">
+<!ENTITY Ctr_extrabarinfo	"Переключение между режимами «Вкладки вверху» и «Вкладки не вверху» меняет расположение дополнительных панелей. Чтобы решить эту проблему, &brandShortName; должен быть перезапущен.">
 
 <!ENTITY Ctr_invicons		"Перекрашенные наоборот значки">
 <!ENTITY Ctr_menubar		"Панель меню">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"В развернутом режиме (вкладки сверху)">
 
 <!ENTITY Ctr_altmenubar		"Добавить цвет фона в строку заголовка операционной системы">
-<!ENTITY Ctr_altmenubarpos	"Изменить расположение (ниже строки заголовка Firefox)">
+<!ENTITY Ctr_altmenubarpos	"Изменить расположение (ниже строки заголовка &brandShortName;)">
 <!ENTITY Ctr_menubarnofog	"Убрать затуманивание/цвет фона (Windows AeroGlass/8)">
 
 <!ENTITY Ctr_aerocolors		"Цвета Blue Aero для основных панелей и вкладок">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Предотвращение активации «Тема разработчика»">
 
 <!ENTITY Ctr_experttweaks	"Продвинутые">
-<!ENTITY Ctr_fx33layers		"С Firefox 33+ новые возможности визуализации, на некоторых системах вызывает ошибки с вкладками (нет реакции, вкладки заморожены). Отключение этой опции решает проблему.">
-<!ENTITY Ctr_fx34search		"С Firefox 34+ новая панель поиска. Отключение этой опции позволяет вернуть старую панель поиска.">
-<!ENTITY Ctr_fx34loop		"С Firefox 34+ добавлен клиент для связи в режиме реального времени. Отключение параметра удаляет эту функцию.">
-<!ENTITY Ctr_fx35devtheme	"С Firefox 35+ введена новая «Тема разработчика». Отключение параметра удаляет её и соответствующую кнопку в режиме «Настройка».">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ настройки в новой вкладке. Если снять этот параметр, то восстанавливает старое окно настроек.">
+<!ENTITY Ctr_fx33layers		"С &brandShortName; 33+ новые возможности визуализации, на некоторых системах вызывает ошибки с вкладками (нет реакции, вкладки заморожены). Отключение этой опции решает проблему.">
+<!ENTITY Ctr_fx34search		"С &brandShortName; 34+ новая панель поиска. Отключение этой опции позволяет вернуть старую панель поиска.">
+<!ENTITY Ctr_fx34loop		"С &brandShortName; 34+ добавлен клиент для связи в режиме реального времени. Отключение параметра удаляет эту функцию.">
+<!ENTITY Ctr_fx35devtheme	"С &brandShortName; 35+ введена новая «Тема разработчика». Отключение параметра удаляет её и соответствующую кнопку в режиме «Настройка».">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ настройки в новой вкладке. Если снять этот параметр, то восстанавливает старое окно настроек.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Настройки">
 <!ENTITY Ctr_pw_set_reset	"Сбросить настройки">
 <!ENTITY Ctr_pw_set_predef	"Классические предустановки">
-<!ENTITY Ctr_pw_set_preaus	"Firefox предустановки">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; предустановки">
 <!ENTITY Ctr_pw_set_export	"Экспорт настроек">
 <!ENTITY Ctr_pw_set_import	"Импорт настроек">
 
 <!ENTITY Ctr_special_font	"Настройки цвета фона — только для темы по умолчанию!">
 <!ENTITY Ctr_special_info	"Некоторые параметры могут предложить визуальные изменения только в определённых случаях!">
-<!ENTITY Ctr_special_info2	"Настройки сделаны для темы Firefox по умолчанию и не могут работать со всеми сторонними темами!">
+<!ENTITY Ctr_special_info2	"Настройки сделаны для темы &brandShortName; по умолчанию и не могут работать со всеми сторонними темами!">
 <!ENTITY Ctr_support		"Форум поддержки">
 <!ENTITY Ctr_newversion		"Новая версия?">
 

--- a/xpi/locale/sl/options.dtd
+++ b/xpi/locale/sl/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Vrstica dodatkov">
@@ -25,7 +35,7 @@
 <!ENTITY Ctr_tabcolors_t	"Barve zavihkov in besedilo">
 
 <!ENTITY Ctr_tabs			"Zavihki">
-<!ENTITY Ctr_tabs0			"Zaokroženi zavihki (Firefoxova privzeta nastavitev)">
+<!ENTITY Ctr_tabs0			"Zaokroženi zavihki (&brandShortName;ova privzeta nastavitev)">
 <!ENTITY Ctr_tabs1			"Pravokotni zavihki (klasični)">
 <!ENTITY Ctr_tabs1m			"Pravokotni zavihki (australizirani)">
 <!ENTITY Ctr_tabs2			"Zaokroženi zavihki (nadomestni)">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Zavihki niso na vrhu (v2) --- atribut [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"v2 je za nekatere dodatke in samo za celotne teme!">
 <!ENTITY Ctr_tabsontopI1	"Atribut [tabsontop=true/false] je dodan k">
-<!ENTITY Ctr_tabsintitlebar	"Nazivna vrstica Firefoxa (nastavitev about:config)">
+<!ENTITY Ctr_tabsintitlebar	"Nazivna vrstica &brandShortName;a (nastavitev about:config)">
 <!ENTITY Ctr_tabwidthdef	"(privzeto)">
 <!ENTITY Ctr_tabwidthcla	"(klasično)">
 <!ENTITY Ctr_tabminheight	"Višina:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Gumb je onemogočen">
 <!ENTITY Ctr_appbutton1		"Gumb na orodni vrstici">
 <!ENTITY Ctr_appbutton1wt	"Gumb na orodni vrstici (samo besedilo)">
-<!ENTITY Ctr_appbutton2		"Gumb na nazivni vrstici [Firefoxa]">
-<!ENTITY Ctr_appbutton2h	"Gumb na nazivni vrstici [Firefoxa] (skrit)">
-<!ENTITY Ctr_appbutton2io	"Gumb na nazivni vrstici [Firefoxa] (samo ikona)">
+<!ENTITY Ctr_appbutton2		"Gumb na nazivni vrstici [&brandShortName;a]">
+<!ENTITY Ctr_appbutton2h	"Gumb na nazivni vrstici [&brandShortName;a] (skrit)">
+<!ENTITY Ctr_appbutton2io	"Gumb na nazivni vrstici [&brandShortName;a] (samo ikona)">
 <!ENTITY Ctr_paneluibtweak	"Oranžni gumb ploščastega menija na orodni vrstici zavihkov">
 <!ENTITY Ctr_appbuttonc_o	"Oranžna barva gumba (privzeto)">
 <!ENTITY Ctr_appbuttonc_a	"Modra barva gumba (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"Bela barva gumba">
 <!ENTITY Ctr_appbuttonc_cu	"Barva gumba po meri">
 <!ENTITY Ctr_appbuttonI1	"Priporočen je ponovni zagon">
-<!ENTITY Ctr_appbuttonI1e	"Ni viden na orodni vrstici OS-a Windows, samo na orodni vrstici Firefoxa!">
+<!ENTITY Ctr_appbuttonI1e	"Ni viden na orodni vrstici OS-a Windows, samo na orodni vrstici &brandShortName;a!">
 <!ENTITY Ctr_appbuttonI2	"Barve gumba so vidne samo na nazivni vrstici in vrstici zavihkov!">
 <!ENTITY Ctr_alttbappb		"Nadomestne ikone brez spustne puščice">
 <!ENTITY Ctr_appbutmhi		"Višji položaj (če se nahaja na orodni vrstici zavihkov)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Pojavno okno ploščastega menija: skrij oznake gumbov">
 <!ENTITY Ctr_menupopupscr	"Pojavna okna menijev: prikaži drsnike namesto drsnih puščic">
 
-<!ENTITY Ctr_fxmockup		"Prototip Firefoxa">
+<!ENTITY Ctr_fxmockup		"Prototip &brandShortName;a">
 <!ENTITY Ctr_tabmokcolor	"Bela barva gumbov zavihkov (Zapri, Nov, Skupine, Seznam vseh)">
 <!ENTITY Ctr_tabmokcolor2	"Bela barva in temna senca besedila nedejavnih zavihkov">
 <!ENTITY Ctr_tabmokcolor3	"Bela barva ločil zavihov">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Dodatne orodne vrstice">
 <!ENTITY Ctr_extrabar0		"Dodatne orodne vrstice">
 <!ENTITY Ctr_extrabar1		"Dodatna orodna vrstica">
-<!ENTITY Ctr_extrabarinfo	"Preklop med načinoma 'Zavihki na vrhu' in 'Zavihki niso na vrhu' naključno spremeni vrstni red dodatnih orodnih vrstic. Za razrešitev te težave morate ponovno zagnati Firefox.">
+<!ENTITY Ctr_extrabarinfo	"Preklop med načinoma 'Zavihki na vrhu' in 'Zavihki niso na vrhu' naključno spremeni vrstni red dodatnih orodnih vrstic. Za razrešitev te težave morate ponovno zagnati &brandShortName;.">
 
 <!ENTITY Ctr_invicons		"Obrnjene ikone">
 <!ENTITY Ctr_menubar		"Vrstica z menijem">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"V razpetem načinu (zavihki na vrhu)">
 
 <!ENTITY Ctr_altmenubar		"Dodaj barvo ozadja (nazivna vrstica OS-a)">
-<!ENTITY Ctr_altmenubarpos	"Nadomestni položaj (pod nazivno vrstico Firefoxa)">
+<!ENTITY Ctr_altmenubarpos	"Nadomestni položaj (pod nazivno vrstico &brandShortName;a)">
 <!ENTITY Ctr_menubarnofog	"Odstrani barvo ozadja/meglo (Windows AeroGlass/8)">
 
 <!ENTITY Ctr_aerocolors		"Modre barve Aero za orodne vrstice (in zavihke)">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prepreči namestitev teme 'Developer Theme'">
 
 <!ENTITY Ctr_experttweaks	"Napredno">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ je vpeljal 'nove možnosti izrisa', ki na nekaterih sistemih povzročajo 'zamrznitev zavihkov'. Odznačitev te nastavitve bo rešila to težavo.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ je vpeljal 'nov ui za iskanje'. Odznačitev te nastavitve povrne 'stari ui za iskanje'.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ je vpeljal možnosti 'klicanja in pogovorov'. Odznačitev te nastavitve jih odstrani.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ je vpeljal novo temo 'Developer theme'. Odznačitev teh nastavitev to temo in pripadajoči gumb v načinu prilagoditve onemogoči.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ je vpeljal nastavitve v zavihku. Odznačitev te nastavitve obnovi staro okno nastavitev.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ je vpeljal 'nove možnosti izrisa', ki na nekaterih sistemih povzročajo 'zamrznitev zavihkov'. Odznačitev te nastavitve bo rešila to težavo.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ je vpeljal 'nov ui za iskanje'. Odznačitev te nastavitve povrne 'stari ui za iskanje'.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ je vpeljal možnosti 'klicanja in pogovorov'. Odznačitev te nastavitve jih odstrani.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ je vpeljal novo temo 'Developer theme'. Odznačitev teh nastavitev to temo in pripadajoči gumb v načinu prilagoditve onemogoči.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ je vpeljal nastavitve v zavihku. Odznačitev te nastavitve obnovi staro okno nastavitev.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Nastavitve">
 <!ENTITY Ctr_pw_set_reset	"Obnovi privzete nastavitve">
 <!ENTITY Ctr_pw_set_predef	"Klasične prednastavljene nastavitve">
-<!ENTITY Ctr_pw_set_preaus	"Firefoxove prednastavljene nastavitve">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName;ove prednastavljene nastavitve">
 <!ENTITY Ctr_pw_set_export	"Izvozi nastavitve">
 <!ENTITY Ctr_pw_set_import	"Uvozi nastavitve">
 
 <!ENTITY Ctr_special_font	"Nastavitve barve ozadja so samo za privzeto temo!">
 <!ENTITY Ctr_special_info	"Nekatere možnosti v vseh primerih morda ne bodo povzročile vidnih sprememb">
-<!ENTITY Ctr_special_info2	"Nastavitve so narejene za Firefoxovo privzeto temo in morda ne bodo delovale z vsemi temami tretjih oseb!">
+<!ENTITY Ctr_special_info2	"Nastavitve so narejene za &brandShortName;ovo privzeto temo in morda ne bodo delovale z vsemi temami tretjih oseb!">
 <!ENTITY Ctr_support		"Forum za podporo">
 <!ENTITY Ctr_newversion		"Nova različica?">
 

--- a/xpi/locale/tr/options.dtd
+++ b/xpi/locale/tr/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Eklenti Çubuğu">
@@ -25,7 +35,7 @@
 <!ENTITY Ctr_tabcolors_t	"Özel Renkler">
 
 <!ENTITY Ctr_tabs			"Sekmeler">
-<!ENTITY Ctr_tabs0			"Kavisli Sekmeler (Firefox varsayılanı)">
+<!ENTITY Ctr_tabs0			"Kavisli Sekmeler (&brandShortName; varsayılanı)">
 <!ENTITY Ctr_tabs1			"Köşeli Sekmeler (Klasik)">
 <!ENTITY Ctr_tabs1m			"Kareli Sekmeler (Australize)">
 <!ENTITY Ctr_tabs2			"Kavisli Sekmeler (Alternatif)">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Sekmeler Tepede Değil - ayarla [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"v2 sadece bazı eklentiler ve tam temalar içindir!">
 <!ENTITY Ctr_tabsontopI1	"Öznitelik Ekler [tabsontop=true/false] to">
-<!ENTITY Ctr_tabsintitlebar	"Firefox başlık çubuğu (about:config)">
+<!ENTITY Ctr_tabsintitlebar	"&brandShortName; başlık çubuğu (about:config)">
 <!ENTITY Ctr_tabwidthdef	"(varsayılan)">
 <!ENTITY Ctr_tabwidthcla	"(klasik)">
 <!ENTITY Ctr_tabminheight	"Yükseklik:">
@@ -66,13 +76,13 @@
 <!ENTITY Ctr_hctpinfotab	"Some tab variations are not compatible to 'Hide Caption Titlebar Plus' add-on.">
 <!ENTITY Ctr_hctpinfoab		"Button on titlebar is not compatible to 'Hide Caption Titlebar Plus' add-on.">
 
-<!ENTITY Ctr_appbutton		"Firefox Butonu">
+<!ENTITY Ctr_appbutton		"&brandShortName; Butonu">
 <!ENTITY Ctr_appbutton0		"Buton devre-dışı">
 <!ENTITY Ctr_appbutton1		"Araç çubuğunda buton">
 <!ENTITY Ctr_appbutton1wt	"Araç çubuğunda buton (sadece yazı)">
-<!ENTITY Ctr_appbutton2		"[Firefox] başlığında buton">
-<!ENTITY Ctr_appbutton2h	"Button on [Firefox] titlebar (hidden)">
-<!ENTITY Ctr_appbutton2io	"[Firefox] başlığında buton (sadece ikon)">
+<!ENTITY Ctr_appbutton2		"[&brandShortName;] başlığında buton">
+<!ENTITY Ctr_appbutton2h	"Button on [&brandShortName;] titlebar (hidden)">
+<!ENTITY Ctr_appbutton2io	"[&brandShortName;] başlığında buton (sadece ikon)">
 <!ENTITY Ctr_paneluibtweak	"Sekme çubuğunda turuncu panel menü butonu">
 <!ENTITY Ctr_appbuttonc_o	"Turuncu renk butonu">
 <!ENTITY Ctr_appbuttonc_a	"Mavi renk butonu (Aurora)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Panel menu uyarısı: buton etikeitini gizle">
 <!ENTITY Ctr_menupopupscr	"Menu uyarısı: kaydırma okları yerine kaydırma çubuklarını göster">
 
-<!ENTITY Ctr_fxmockup		"Firefox Taklit Modeli">
+<!ENTITY Ctr_fxmockup		"&brandShortName; Taklit Modeli">
 <!ENTITY Ctr_tabmokcolor	"Sekme butonları için beyaz renk (kapat, yeni, gruplar, tümünü listele)">
 <!ENTITY Ctr_tabmokcolor2	"Yazılar ve aktif olmayan sekmeler için beyaz renk ve karanlık gölge">
 <!ENTITY Ctr_tabmokcolor3	"Sekme ayırıcıları için Beyaz renk kullan">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Ek Araç Çubuğu">
 <!ENTITY Ctr_extrabar0		"Ek Araç Çubuk(ları)">
 <!ENTITY Ctr_extrabar1		"Ek Araç Çubuğu">
-<!ENTITY Ctr_extrabarinfo	"'Sekmeler yukarıda' ve 'Sekmeler yukarıda olmadığı' modlar arası değişmek, bazen araç çubuklarını bozabilir. Firefox bu sorunu çözmek için yeniden başlatılması gerekir.">
+<!ENTITY Ctr_extrabarinfo	"'Sekmeler yukarıda' ve 'Sekmeler yukarıda olmadığı' modlar arası değişmek, bazen araç çubuklarını bozabilir. &brandShortName; bu sorunu çözmek için yeniden başlatılması gerekir.">
 
 <!ENTITY Ctr_invicons		"Ters çevrilmiş simgeleri">
 <!ENTITY Ctr_menubar		"Menu çubuğu">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"In maximized mode (tabs on top)">
 
 <!ENTITY Ctr_altmenubar		"Arkaplan rengi ekle (OS başlıkçubuğunda)">
-<!ENTITY Ctr_altmenubarpos	"Alternatif pozisyon (Firefox başlık çubuğunda altında)">
+<!ENTITY Ctr_altmenubarpos	"Alternatif pozisyon (&brandShortName; başlık çubuğunda altında)">
 <!ENTITY Ctr_menubarnofog	"Arkaplan bulanıklığı/rengi kaldır (Windows AeroGlass/8)">
 
 <!ENTITY Ctr_aerocolors		"Blue Aero colors for toolbars (and tabs)">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prevent 'Developer Theme' from being enabled">
 
 <!ENTITY Ctr_experttweaks	"Gelişmiş">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ introduced 'new render features' currently responsible for 'hanging tabs' on some systems. Unchecking this preference resolves this issue.">
-<!ENTITY Ctr_fx34search		"Firefox 34+ introduced a 'new seach ui'. Unchecking this preference returns the 'old seach ui'.">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ introduced 'calling and conversation' features. Unchecking this preference removes them.">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ introduced 'new render features' currently responsible for 'hanging tabs' on some systems. Unchecking this preference resolves this issue.">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ introduced a 'new seach ui'. Unchecking this preference returns the 'old seach ui'.">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ introduced 'calling and conversation' features. Unchecking this preference removes them.">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Ayarlar">
 <!ENTITY Ctr_pw_set_reset	"Sıfırla">
 <!ENTITY Ctr_pw_set_predef	"Klasik ön-tanımlı">
-<!ENTITY Ctr_pw_set_preaus	"Firefox ön-tanımlı">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; ön-tanımlı">
 <!ENTITY Ctr_pw_set_export	"Tercihleri dışa Aktar">
 <!ENTITY Ctr_pw_set_import	"Tercihleri içe Aktar">
 
 <!ENTITY Ctr_special_font	"Arka plan renk ayarları varsayılan tema içindir!">
 <!ENTITY Ctr_special_info	"Bazı seçenekler, yalnızca belirli durumlarda görsel değişiklikler yapabilir!">
-<!ENTITY Ctr_special_info2	"Ayarlar Firefox varsayılan teması için yapılmıştır ve diğer üçüncü parti temalar ile çalışmayabilir!">
+<!ENTITY Ctr_special_info2	"Ayarlar &brandShortName; varsayılan teması için yapılmıştır ve diğer üçüncü parti temalar ile çalışmayabilir!">
 <!ENTITY Ctr_support		"Destek Forumu">
 <!ENTITY Ctr_newversion		"Yeni versiyon?">
 

--- a/xpi/locale/uk/options.dtd
+++ b/xpi/locale/uk/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"Панель додатків">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"Індикатор активності">
 <!ENTITY Ctr_sidebarbutton	"Бокова панель">
 <!ENTITY Ctr_windowcontrols	"мін/макс/закрити (Повний екран)">
-<!ENTITY Ctr_rr				"Перезапустіть Firefox!">
+<!ENTITY Ctr_rr				"Перезапустіть &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"Кнопки">
 <!ENTITY Ctr_cuibutnormal	"Нормальні">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"Вкладки не нагорі (v2) --- встановлено [tabsontop=false]">
 <!ENTITY Ctr_tabsontopW1	"v2 - тільки для деяких додатків і повних тем!">
 <!ENTITY Ctr_tabsontopI1	"Додає атрибут [tabsontop=true/false] для">
-<!ENTITY Ctr_tabsintitlebar	"Панель заголовку Firefox (about:config preference)">
+<!ENTITY Ctr_tabsintitlebar	"Панель заголовку &brandShortName; (about:config preference)">
 <!ENTITY Ctr_tabwidthdef	"(типово)">
 <!ENTITY Ctr_tabwidthcla	"(класичний)">
 <!ENTITY Ctr_tabminheight	"Висота:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"Кнопка вимкнена">
 <!ENTITY Ctr_appbutton1		"Кнопка на панелі">
 <!ENTITY Ctr_appbutton1wt	"Кнопка на панелі (тільки текст)">
-<!ENTITY Ctr_appbutton2		"Кнопка на [Firefox] панелі заголовку">
-<!ENTITY Ctr_appbutton2h	"Кнопка на [Firefox] панелі заголовку (прихована)">
-<!ENTITY Ctr_appbutton2io	"Кнопка на [Firefox] панелі заголовку (тільки іконка)">
+<!ENTITY Ctr_appbutton2		"Кнопка на [&brandShortName;] панелі заголовку">
+<!ENTITY Ctr_appbutton2h	"Кнопка на [&brandShortName;] панелі заголовку (прихована)">
+<!ENTITY Ctr_appbutton2io	"Кнопка на [&brandShortName;] панелі заголовку (тільки іконка)">
 <!ENTITY Ctr_paneluibtweak	"Оранжева кнопка меню на панелі вкладок">
 <!ENTITY Ctr_appbuttonc_o	"Оранжева кнопка (типово)">
 <!ENTITY Ctr_appbuttonc_a	"Синя кнопка (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"Біла кнопка">
 <!ENTITY Ctr_appbuttonc_cu	"Вибрати колір кнопки">
 <!ENTITY Ctr_appbuttonI1	"рекомендовано перезапуск">
-<!ENTITY Ctr_appbuttonI1e	"Не видно в рядку заголовку Windows OS, тільки в Firefox заголовку!">
+<!ENTITY Ctr_appbuttonI1e	"Не видно в рядку заголовку Windows OS, тільки в &brandShortName; заголовку!">
 <!ENTITY Ctr_appbuttonI2	"Кольори кнопок видимі тільки на панелях заголовку і вкладок!">
 <!ENTITY Ctr_alttbappb		"Альтернативні іконки">
 <!ENTITY Ctr_appbutmhi		"Вища позиція (якщо на панелі вкладок)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"Спливаюче вікно панелі меню: приховати написи на кнопках">
 <!ENTITY Ctr_menupopupscr	"Спливаючі вікна меню: показувати полоси прокручування замість стрілки прокручування">
 
-<!ENTITY Ctr_fxmockup		"Firefox макет">
+<!ENTITY Ctr_fxmockup		"&brandShortName; макет">
 <!ENTITY Ctr_tabmokcolor	"Білий колір для кнопок вкладок (закрити, нова, групи, список усіх)">
 <!ENTITY Ctr_tabmokcolor2	"Білий колір і темна тінь для тексту на неактивній вкладці">
 <!ENTITY Ctr_tabmokcolor3	"Білий колір для розділювачів вкладок">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"Додаткові панелі інструментів">
 <!ENTITY Ctr_extrabar0		"Додаткова панель(і)">
 <!ENTITY Ctr_extrabar1		"Додаткова панель">
-<!ENTITY Ctr_extrabarinfo	"Перемикання між способами «вкладки нагорі» і «вкладки не нагорі» змінює розташування додаткових панелей. Firefox повинен бути перезапущений, щоб вирішити цю проблему.">
+<!ENTITY Ctr_extrabarinfo	"Перемикання між способами «вкладки нагорі» і «вкладки не нагорі» змінює розташування додаткових панелей. &brandShortName; повинен бути перезапущений, щоб вирішити цю проблему.">
 
 <!ENTITY Ctr_invicons		"Інвертовані іконки">
 <!ENTITY Ctr_menubar		"Панель меню">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"У розширеному режимі (вкладки нагорі)">
 
 <!ENTITY Ctr_altmenubar		"Додати колір тла (рядок заголовку Windows)">
-<!ENTITY Ctr_altmenubarpos	"Альтернативна позиція (нижче рядку заголовку Firefox)">
+<!ENTITY Ctr_altmenubarpos	"Альтернативна позиція (нижче рядку заголовку &brandShortName;)">
 <!ENTITY Ctr_menubarnofog	"Прибрати затуманення/колір тла (Windows AeroGlass/8)">
 
 <!ENTITY Ctr_aerocolors		"Кольори Blue Aero для основних панелей і вкладок">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Запобігти увімкненню «Теми розробника»">
 
 <!ENTITY Ctr_experttweaks	"Розширені опції">
-<!ENTITY Ctr_fx33layers		"В Firefox 33+ введено «нові візуальні особливості», які в даний час відповідають за «зависання» вкладок на деяких системах. Вимкнення цього параметра вирішує цю проблему.">
-<!ENTITY Ctr_fx34search		"В Firefox 34+ введено «новий пошуковий інтерфейс». Вимкнення цього параметра поверне  «старий пошуковий інтерфейс».">
-<!ENTITY Ctr_fx34loop		"В Firefox 34+ введені особливості «виклику та сеансу зв’язку». Вимкнення цього параметру видалить їх.">
-<!ENTITY Ctr_fx35devtheme	"В Firefox 35+ введено нову «тему» від розробника. Вимкнення цих налаштувань вимикає цю «тему» і її кнопку в ручному режимі налаштувань.">
-<!ENTITY Ctr_fx36prefs		"В Firefox 36+ введено нове налаштування у вкладці. Вимкнення цього пункту відновлює вікно зі старими налаштуванням.">
+<!ENTITY Ctr_fx33layers		"В &brandShortName; 33+ введено «нові візуальні особливості», які в даний час відповідають за «зависання» вкладок на деяких системах. Вимкнення цього параметра вирішує цю проблему.">
+<!ENTITY Ctr_fx34search		"В &brandShortName; 34+ введено «новий пошуковий інтерфейс». Вимкнення цього параметра поверне  «старий пошуковий інтерфейс».">
+<!ENTITY Ctr_fx34loop		"В &brandShortName; 34+ введені особливості «виклику та сеансу зв’язку». Вимкнення цього параметру видалить їх.">
+<!ENTITY Ctr_fx35devtheme	"В &brandShortName; 35+ введено нову «тему» від розробника. Вимкнення цих налаштувань вимикає цю «тему» і її кнопку в ручному режимі налаштувань.">
+<!ENTITY Ctr_fx36prefs		"В &brandShortName; 36+ введено нове налаштування у вкладці. Вимкнення цього пункту відновлює вікно зі старими налаштуванням.">
 <!ENTITY Ctr_e_omtc			"OMTC / проблеми завислих вкладок">
 <!ENTITY Ctr_e_searchui		"Вигляд панелі Пошук">
 <!ENTITY Ctr_e_loop			"Виклик та сеанс зв’язку">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"Налаштування">
 <!ENTITY Ctr_pw_set_reset	"Скинути налаштування">
 <!ENTITY Ctr_pw_set_predef	"Класичні налаштунки">
-<!ENTITY Ctr_pw_set_preaus	"Firefox налаштунок">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; налаштунок">
 <!ENTITY Ctr_pw_set_export	"Експорт налаштувань">
 <!ENTITY Ctr_pw_set_import	"Імпорт налаштувань">
 
 <!ENTITY Ctr_special_font	"Налаштування кольору тла - тільки для типової теми!">
 <!ENTITY Ctr_special_info	"Деякі параметри не можуть запропонувати візуальні зміни в усіх випадках">
-<!ENTITY Ctr_special_info2	"Налаштування зроблені для типової теми Firefox і не можуть працювати з усіма сторонніми темами!">
+<!ENTITY Ctr_special_info2	"Налаштування зроблені для типової теми &brandShortName; і не можуть працювати з усіма сторонніми темами!">
 <!ENTITY Ctr_support		"Форум підтримки">
 <!ENTITY Ctr_newversion		"Нова версія?">
 

--- a/xpi/locale/zh-CN/options.dtd
+++ b/xpi/locale/zh-CN/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"附加组件栏">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"活动指示器">
 <!ENTITY Ctr_sidebarbutton	"侧边栏">
 <!ENTITY Ctr_windowcontrols	"最小化/最大化/关闭 (全屏)">
-<!ENTITY Ctr_rr				"需要重启 Firefox!">
+<!ENTITY Ctr_rr				"需要重启 &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"按钮">
 <!ENTITY Ctr_cuibutnormal	"标准">
@@ -25,7 +35,7 @@
 <!ENTITY Ctr_tabcolors_t	"标签页颜色与文本">
 
 <!ENTITY Ctr_tabs			"标签页">
-<!ENTITY Ctr_tabs0			"弧形标签页 (Firefox 默认)">
+<!ENTITY Ctr_tabs0			"弧形标签页 (&brandShortName; 默认)">
 <!ENTITY Ctr_tabs1			"方形标签页 (经典)">
 <!ENTITY Ctr_tabs1m			"方形标签页 (仿 Australis)">
 <!ENTITY Ctr_tabs2			"弧形标签页 (备选风格)">
@@ -38,7 +48,7 @@
 <!ENTITY Ctr_tabsontop3		"标签栏不在顶部 (v2) --- [tabsontop=false] 属性">
 <!ENTITY Ctr_tabsontopW1	"v2 仅适用于部分扩展与完整主题!">
 <!ENTITY Ctr_tabsontopI1	"添加属性 [tabsontop=true/false] 至">
-<!ENTITY Ctr_tabsintitlebar	"Firefox 标题栏 (about:config 选项)">
+<!ENTITY Ctr_tabsintitlebar	"&brandShortName; 标题栏 (about:config 选项)">
 <!ENTITY Ctr_tabwidthdef	"(默认)">
 <!ENTITY Ctr_tabwidthcla	"(经典)">
 <!ENTITY Ctr_tabminheight	"高度:">
@@ -70,9 +80,9 @@
 <!ENTITY Ctr_appbutton0		"按钮已禁用">
 <!ENTITY Ctr_appbutton1		"在工具栏上显示">
 <!ENTITY Ctr_appbutton1wt	"在工具栏上显示 (仅文本)">
-<!ENTITY Ctr_appbutton2		"在 [Firefox] 标题栏上显示">
-<!ENTITY Ctr_appbutton2h	"在 [Firefox] 标题栏上显示 (隐藏)">
-<!ENTITY Ctr_appbutton2io	"在 [Firefox] 标题栏上显示 (仅图标)">
+<!ENTITY Ctr_appbutton2		"在 [&brandShortName;] 标题栏上显示">
+<!ENTITY Ctr_appbutton2h	"在 [&brandShortName;] 标题栏上显示 (隐藏)">
+<!ENTITY Ctr_appbutton2io	"在 [&brandShortName;] 标题栏上显示 (仅图标)">
 <!ENTITY Ctr_paneluibtweak	"在标签页栏上显示橙色面板菜单按钮">
 <!ENTITY Ctr_appbuttonc_o	"橙色按钮 (默认)">
 <!ENTITY Ctr_appbuttonc_a	"蓝色按钮 (Aurora)">
@@ -86,7 +96,7 @@
 <!ENTITY Ctr_appbuttonc_wh	"白色按钮">
 <!ENTITY Ctr_appbuttonc_cu	"自定义按钮颜色">
 <!ENTITY Ctr_appbuttonI1	"建议重启浏览器">
-<!ENTITY Ctr_appbuttonI1e	"在 Windows 系统标题栏上不可见，仅在 Firefox 标题栏上!">
+<!ENTITY Ctr_appbuttonI1e	"在 Windows 系统标题栏上不可见，仅在 &brandShortName; 标题栏上!">
 <!ENTITY Ctr_appbuttonI2	"按钮颜色只在标题栏与标签页栏上可见!">
 <!ENTITY Ctr_alttbappb		"备选的不带下拉三角图标">
 <!ENTITY Ctr_appbutmhi		"更高的位置 (如果在标签页栏上)">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"面板菜单: 隐藏按钮标签文本">
 <!ENTITY Ctr_menupopupscr	"弹出式菜单: 用滚动栏代替滚动箭头">
 
-<!ENTITY Ctr_fxmockup		"Firefox 样式">
+<!ENTITY Ctr_fxmockup		"&brandShortName; 样式">
 <!ENTITY Ctr_tabmokcolor	"白色标签页按钮 (关闭, 新建, 分组, 显示所有)">
 <!ENTITY Ctr_tabmokcolor2	"在非激活标签页上使用白色文字并添加文字阴影">
 <!ENTITY Ctr_tabmokcolor3	"白色标签页分隔符">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"附加工具栏">
 <!ENTITY Ctr_extrabar0		"附加工具栏">
 <!ENTITY Ctr_extrabar1		"附加工具栏">
-<!ENTITY Ctr_extrabarinfo	"在“标签页置顶”和“标签页不置顶”模式间切换会随机修改附加工具栏的顺序。需要重启 Firefox 来解决该问题。">
+<!ENTITY Ctr_extrabarinfo	"在“标签页置顶”和“标签页不置顶”模式间切换会随机修改附加工具栏的顺序。需要重启 &brandShortName; 来解决该问题。">
 
 <!ENTITY Ctr_invicons		"反转图标">
 <!ENTITY Ctr_menubar		"菜单栏">
@@ -215,7 +225,7 @@
 <!ENTITY Ctr_alttabstb2		"在最大化模式 (标签在顶部)">
 
 <!ENTITY Ctr_altmenubar		"添加背景颜色 (操作系统标题栏)">
-<!ENTITY Ctr_altmenubarpos	"备选位置 (在 Firefox 标题栏下方)">
+<!ENTITY Ctr_altmenubarpos	"备选位置 (在 &brandShortName; 标题栏下方)">
 <!ENTITY Ctr_menubarnofog	"移除背景颜色/模糊 (Windows AeroGlass/8)">
 
 <!ENTITY Ctr_aerocolors		"主工具栏和标签页使用蓝色 Aero 颜色">
@@ -242,7 +252,7 @@
 <!ENTITY Ctr_dlanimation	"“下载提醒”动画 (about:config 选项)">
 
 <!ENTITY Ctr_toolsitem		"在工具菜单中显示菜单项">
-<!ENTITY Ctr_appmenuitem	"在 Firefox 按钮菜单中显示菜单项">
+<!ENTITY Ctr_appmenuitem	"在 &brandShortName; 按钮菜单中显示菜单项">
 <!ENTITY Ctr_contextitem	"在工具栏右键菜单中显示菜单项">
 <!ENTITY Ctr_puictrbutton	"在主面板菜单中显示按钮">
 
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"阻止“开发者主题”被启用">
 
 <!ENTITY Ctr_experttweaks	"高级">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ 引入“新渲染器功能”目前可能是某些系统“标签页卡死”的主要原因。不选中此项以解决该问题。">
-<!ENTITY Ctr_fx34search		"Firefox 34+ 引入“新搜索界面”。不选中此项以恢复“旧搜索界面”。">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ 引入“呼叫和通话”功能。不选中此项以移除它们。">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ 引入新的“开发者主题”。不选中此项以禁用“开发者主题”以及定制模式下它的一些按钮。">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ 引入在标签页中显示选项设置。不选中此项以使用旧选项窗口。">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ 引入“新渲染器功能”目前可能是某些系统“标签页卡死”的主要原因。不选中此项以解决该问题。">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ 引入“新搜索界面”。不选中此项以恢复“旧搜索界面”。">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ 引入“呼叫和通话”功能。不选中此项以移除它们。">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ 引入新的“开发者主题”。不选中此项以禁用“开发者主题”以及定制模式下它的一些按钮。">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ 引入在标签页中显示选项设置。不选中此项以使用旧选项窗口。">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"设置">
 <!ENTITY Ctr_pw_set_reset	"恢复默认">
 <!ENTITY Ctr_pw_set_predef	"经典主题预设">
-<!ENTITY Ctr_pw_set_preaus	"Firefox 预设">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; 预设">
 <!ENTITY Ctr_pw_set_export	"导出选项设置">
 <!ENTITY Ctr_pw_set_import	"导入选项设置">
 
 <!ENTITY Ctr_special_font	"只有默认主题才能设置背景颜色!">
 <!ENTITY Ctr_special_info	"一些选项可能无法在所有情况下提供视觉变化!">
-<!ENTITY Ctr_special_info2	"有些设置只能在 Firefox 默认主题中生效，第三方主题可能无法生效!">
+<!ENTITY Ctr_special_info2	"有些设置只能在 &brandShortName; 默认主题中生效，第三方主题可能无法生效!">
 <!ENTITY Ctr_support		"支持讨论区">
 <!ENTITY Ctr_newversion		"有新版本?">
 

--- a/xpi/locale/zh-TW/options.dtd
+++ b/xpi/locale/zh-TW/options.dtd
@@ -1,3 +1,13 @@
+<!-- LOCALIZATION NOTE (<!ENTITY % brandDTD) must not be edited as it  
+	   controls the use of (&brandShortName;) this gets replaced at run time
+	   with the browsers name, This item can not be edited or errors may occur.
+-->
+<!-- Do not edit -->
+<!ENTITY % brandDTD
+    SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+<!-- Do not edit above this message--> 
+
 <!ENTITY Ctr_title			"Classic Theme Restorer">
 
 <!ENTITY Ctr_addonbar		"附加元件列">
@@ -9,7 +19,7 @@
 <!ENTITY Ctr_navthrobber	"進度指示器">
 <!ENTITY Ctr_sidebarbutton	"側邊欄">
 <!ENTITY Ctr_windowcontrols	"最小化/最大化/關閉 (全螢幕)">
-<!ENTITY Ctr_rr				"需重啟 Firefox!">
+<!ENTITY Ctr_rr				"需重啟 &brandShortName;!">
 
 <!ENTITY Ctr_cuibuttons		"按鈕">
 <!ENTITY Ctr_cuibutnormal	"標準圖示">
@@ -139,7 +149,7 @@
 <!ENTITY Ctr_pmhidelabels	"面板選單: 隱藏按鈕文字標籤">
 <!ENTITY Ctr_menupopupscr	"彈出式選單: 用捲軸取代捲動箭頭">
 
-<!ENTITY Ctr_fxmockup		"Firefox 樣式">
+<!ENTITY Ctr_fxmockup		"&brandShortName; 樣式">
 <!ENTITY Ctr_tabmokcolor	"白色分頁按鈕 (關閉、新增、分頁群組、列出所有分頁)">
 <!ENTITY Ctr_tabmokcolor2	"非目前的分頁，其字型使用白色文字，並加上文字陰影">
 <!ENTITY Ctr_tabmokcolor3	"白色分頁分隔線">
@@ -191,7 +201,7 @@
 <!ENTITY Ctr_extrabar		"新增工具列">
 <!ENTITY Ctr_extrabar0		"新增工具列">
 <!ENTITY Ctr_extrabar1		"新增工具列">
-<!ENTITY Ctr_extrabarinfo	"在「分頁列置頂」、「分頁列不置頂」兩模式間切換，會隨機排列「新增工具列」的順序。重啟 Firefox 方可解決這問題。">
+<!ENTITY Ctr_extrabarinfo	"在「分頁列置頂」、「分頁列不置頂」兩模式間切換，會隨機排列「新增工具列」的順序。重啟 &brandShortName; 方可解決這問題。">
 
 <!ENTITY Ctr_invicons		"圖示反相">
 <!ENTITY Ctr_menubar		"選單列">
@@ -252,11 +262,11 @@
 <!ENTITY Ctr_nodevtheme		"Prevent 'Developer Theme' from being enabled">
 
 <!ENTITY Ctr_experttweaks	"進階">
-<!ENTITY Ctr_fx33layers		"Firefox 33+ 啟用了「OMTC」，目的是改善瀏覽器響應速度，但某些硬體組合環境下可能造成故障。取消勾選這個核取方塊 ，可解決相關問題。">
-<!ENTITY Ctr_fx34search		"Firefox 34+ 引入了「新搜尋列介面」。取消勾選這個核取方塊 ，則可恢復為「舊式搜尋列介面」。">
-<!ENTITY Ctr_fx34loop		"Firefox 34+ 實作了「Firefox Hello 即時通訊」功能。取消勾選這個核取方塊 ，則可移除這項功能。">
-<!ENTITY Ctr_fx35devtheme	"Firefox 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
-<!ENTITY Ctr_fx36prefs		"Firefox 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
+<!ENTITY Ctr_fx33layers		"&brandShortName; 33+ 啟用了「OMTC」，目的是改善瀏覽器響應速度，但某些硬體組合環境下可能造成故障。取消勾選這個核取方塊 ，可解決相關問題。">
+<!ENTITY Ctr_fx34search		"&brandShortName; 34+ 引入了「新搜尋列介面」。取消勾選這個核取方塊 ，則可恢復為「舊式搜尋列介面」。">
+<!ENTITY Ctr_fx34loop		"&brandShortName; 34+ 實作了「&brandShortName; Hello 即時通訊」功能。取消勾選這個核取方塊 ，則可移除這項功能。">
+<!ENTITY Ctr_fx35devtheme	"&brandShortName; 35+ introduced a new 'developer theme'. Unchecking these preferences disables the 'developer theme' and its button in customizing mode.">
+<!ENTITY Ctr_fx36prefs		"&brandShortName; 36+ introduced 'preferences in tab'. Unchecking this preference restores the old preference window.">
 <!ENTITY Ctr_e_omtc			"OMTC / hanging tabs issue">
 <!ENTITY Ctr_e_searchui		"Search appearance">
 <!ENTITY Ctr_e_loop			"Calling and conversation">
@@ -267,13 +277,13 @@
 <!ENTITY Ctr_pw_settings	"設定">
 <!ENTITY Ctr_pw_set_reset	"套件預設值">
 <!ENTITY Ctr_pw_set_predef	"經典設定值">
-<!ENTITY Ctr_pw_set_preaus	"Firefox 預設值">
+<!ENTITY Ctr_pw_set_preaus	"&brandShortName; 預設值">
 <!ENTITY Ctr_pw_set_export	"匯出設定值">
 <!ENTITY Ctr_pw_set_import	"匯入設定值">
 
 <!ENTITY Ctr_special_font	"背景色彩設定僅生效於預設佈景主題!">
 <!ENTITY Ctr_special_info	"部份選項僅在某些情況下提供視覺上的變化!">
-<!ENTITY Ctr_special_info2	"設定僅在 Firefox 的預設佈景主題下測試，因此可能不生效於第三方佈景主題!">
+<!ENTITY Ctr_special_info2	"設定僅在 &brandShortName; 的預設佈景主題下測試，因此可能不生效於第三方佈景主題!">
 <!ENTITY Ctr_support		"技術支援討論區">
 <!ENTITY Ctr_newversion		"有新版本?">
 


### PR DESCRIPTION
This proposed patch contains a few little patches.

The first change is to __`options.dtd`__ localization files, Here i have imported the browser __`brand.dtd`__ This has access to the default global application short name and if a language pack is installed the localized version if supplied.

This allows the use of __`&brandShortName;`__ inside __`options.dtd`__ which at browser run-time is replaced with the browsers short name, In this case Firefox or if installed in to a re-branded browser its browser short name like TOR.

The Second change same localization system has been applied to __`overlay.dtd`__ to dynamically add the browsers branding to the base of Classic Theme Restorer.

The third change uses the imported __`Services.jsm`__
```javascript
Components.utils.import("resource://gre/modules/Services.jsm");
```
Since its imported we have access to features it contains like 
- nsIXULRuntime
- nsIAppStartup
- nsIStringBundleService
This can also shrink the amount of code needed when calling these functions.

The forth change is in 
```javascript
unloadprefwindow: function() {}
```
This change is in the __`options.js`__ restart event when the preference window is being unloaded.
Here two declared variables are being removed as __Services.__ is being used directly in its place.
This change uses __Services.prompt__ and __Services.startup__


P.s I hope you can find use of these proposed changes or pick the ones you can use.