### PR TITLE
Replaced brandDTD namespace with overlayDTD.

### DIFF
--- a/xpi/locale/cs/options.dtd
+++ b/xpi/locale/cs/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/da/options.dtd
+++ b/xpi/locale/da/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/de/options.dtd
+++ b/xpi/locale/de/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/dsb/options.dtd
+++ b/xpi/locale/dsb/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/el/options.dtd
+++ b/xpi/locale/el/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Επαναφορέας κλασικού θέματος">

--- a/xpi/locale/en-US/options.dtd
+++ b/xpi/locale/en-US/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/es/options.dtd
+++ b/xpi/locale/es/options.dtd
@@ -1,6 +1,6 @@
-﻿<!ENTITY % brandDTD
+﻿<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/fr/options.dtd
+++ b/xpi/locale/fr/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/hsb/options.dtd
+++ b/xpi/locale/hsb/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/it/options.dtd
+++ b/xpi/locale/it/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title 			"Classic Theme Restorer">

--- a/xpi/locale/ja/options.dtd
+++ b/xpi/locale/ja/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/pl/options.dtd
+++ b/xpi/locale/pl/options.dtd
@@ -1,6 +1,6 @@
-﻿<!ENTITY % brandDTD
+﻿<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/pt-BR/options.dtd
+++ b/xpi/locale/pt-BR/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/ru/options.dtd
+++ b/xpi/locale/ru/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/sl/options.dtd
+++ b/xpi/locale/sl/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/tr/options.dtd
+++ b/xpi/locale/tr/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/uk/options.dtd
+++ b/xpi/locale/uk/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/zh-CN/options.dtd
+++ b/xpi/locale/zh-CN/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">

--- a/xpi/locale/zh-TW/options.dtd
+++ b/xpi/locale/zh-TW/options.dtd
@@ -1,6 +1,6 @@
-<!ENTITY % brandDTD
+<!ENTITY % overlayDTD
     SYSTEM "chrome://classic_theme_restorer/content/overlay.dtd">
-  %brandDTD;
+  %overlayDTD;
 <!-- Do not edit above this line and do not edit the variable '&brandShortName;' inside translated strings -->
 
 <!ENTITY Ctr_title			"Classic Theme Restorer">


### PR DESCRIPTION
This namespace was renamed to `%overlayDTD;` due to conflicts if you import brand.dtd as the brand.dtd uses `%brandDTD;` namespace.