### PR TITLE
Reduce CTRpreferences.json file size by almost half.

### DIFF
--- a/xpi/content/options.js
+++ b/xpi/content/options.js
@@ -1079,7 +1079,10 @@ classicthemerestorerjso.ctr = {
 	  try {
 
 		if(parjson[i].preference.match(/extensions.classicthemerestorer./g)){
+			//To import previously generated preference export.
 			setPrefValue(parjson[i].preference, parjson[i].value);
+		}else{
+			setPrefValue('extensions.classicthemerestorer.' + parjson[i].preference, parjson[i].value);
 		}
 
 	  } catch(e) {
@@ -1165,7 +1168,7 @@ classicthemerestorerjso.ctr = {
 		}
 
 		preferenceArray.preference.push({
-		  "preference" : preflist[i],
+		  "preference" : preflist[i].replace("extensions.classicthemerestorer.", ""),
 		  "value" : prefValue(preflist[i])
 		});
 


### PR DESCRIPTION
Here you can reduce the export of CTRpreferences.json by almost half.

Also allow the import of the older larger generated CTRpreferences.json as not to break older exports.

In both cases only the import of CTR based preferences can be done, If a
non CTR preference manages to be imported it will be prefixed with the
CTR prefix making it invalid.