### PR TITLE
Fix-up Name-spacing (addonManager, Services) and other imports

### DIFF
--- a/xpi/content/aboutnewtab.js
+++ b/xpi/content/aboutnewtab.js
@@ -1,10 +1,26 @@
 "use strict";
+(function(global) {
+var Cu = Components.utils;
 
-Cu.import("resource://gre/modules/Services.jsm");
+var {Services} = Cu.import("resource://gre/modules/Services.jsm", {});
 
-if(Services.prefs.getBranch('extensions.classicthemerestorer.').getBoolPref('alt_newtabp')) {
-  try{
-	if(parseInt(Services.prefs.getBranch("extensions.").getCharPref("lastAppVersion")) >= 40)
-	  document.getElementById("newtab-window").setAttribute('fx40plus',true);
-  } catch(e){}
+if (typeof ctrAboutNewTab  == "undefined") {
+    var ctrAboutNewTab  = {};
+};
+if (!ctrAboutNewTab ) {
+    ctrAboutNewTab  = {};
+};
+ 
+ctrAboutNewTab = {
+	init : function(){		
+		if(Services.prefs.getBranch('extensions.classicthemerestorer.').getBoolPref('alt_newtabp')) {
+		  try{
+			if(parseInt(Services.prefs.getBranch("extensions.").getCharPref("lastAppVersion")) >= 40)
+			  document.getElementById("newtab-window").setAttribute('fx40plus',true);
+		  } catch(e){}
+		}		
+	}
 }
+  // Make ctrAboutNewTab a global variable
+  global.ctrAboutNewTab = ctrAboutNewTab;
+}(this));

--- a/xpi/content/aboutnewtab.xul
+++ b/xpi/content/aboutnewtab.xul
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<overlay xmlns="http://www.w3.org/1999/xhtml" xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+<overlay xmlns="http://www.w3.org/1999/xhtml" xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul" onload="ctrAboutNewTab.init();">
 
   <script type="application/x-javascript" src="aboutnewtab.js"/>
   

--- a/xpi/content/options.js
+++ b/xpi/content/options.js
@@ -1,14 +1,15 @@
 "use strict";
+(function(global) {
 if (typeof classicthemerestorerjso == "undefined") {var classicthemerestorerjso = {};};
 if (!classicthemerestorerjso.ctr) {classicthemerestorerjso.ctr = {};};
 
-Components.utils.import("resource://gre/modules/AddonManager.jsm");
-Components.utils.import("resource:///modules/CustomizableUI.jsm");
+var Cc = Components.classes, Ci = Components.interfaces, Cu = Components.utils;
+
+var {CustomizableUI} = Cu.import("resource:///modules/CustomizableUI.jsm", {});
+var {AddonManager} = Cu.import("resource://gre/modules/AddonManager.jsm", {});
 
 //Import services use one service for preferences.
-Components.utils.import("resource://gre/modules/Services.jsm");
-//Query nsIPrefBranch see: Bug 1125570 | Bug 1083561
-Services.prefs.QueryInterface(Components.interfaces.nsIPrefBranch);
+var {Services} = Cu.import("resource://gre/modules/Services.jsm", {});
 
 classicthemerestorerjso.ctr = {
 
@@ -337,7 +338,7 @@ classicthemerestorerjso.ctr = {
 	  // Keeping a reference to the observed preference branch or it will get
 	  // garbage collected.
 	  this._branch = Services.prefs.getBranch(branch_name);
-	  this._branch.QueryInterface(Components.interfaces.nsIPrefBranch2);
+	  this._branch.QueryInterface(Ci.nsIPrefBranch2);
 	  this._callback = callback;
 	}
 
@@ -457,8 +458,8 @@ classicthemerestorerjso.ctr = {
      when preference window gets closed */
   unloadprefwindow: function() {
 
-	var cancelQuit   = Components.classes["@mozilla.org/supports-PRBool;1"].createInstance(Components.interfaces.nsISupportsPRBool);
-	var observerSvc  = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
+	var cancelQuit   = Cc["@mozilla.org/supports-PRBool;1"].createInstance(Ci.nsISupportsPRBool);
+	var observerSvc  = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
 	var stringBundle = Services.strings.createBundle("chrome://classic_theme_restorer/locale/messages.file");
 						
 	var brandName	 = '';
@@ -940,7 +941,7 @@ classicthemerestorerjso.ctr = {
 
 	  } catch(e) {
 		// Report errors to console
-		Components.utils.reportError(e);
+		Cu.reportError(e);
 	  }
 
 	}	  
@@ -950,9 +951,9 @@ classicthemerestorerjso.ctr = {
 	  
 	function saveToFile(patterns) {
 
-	  const nsIFilePicker = Components.interfaces.nsIFilePicker;
-	  var fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
-	  var stream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(Components.interfaces.nsIFileOutputStream);
+	  const nsIFilePicker = Ci.nsIFilePicker;
+	  var fp = Cc["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
+	  var stream = Cc["@mozilla.org/network/file-output-stream;1"].createInstance(Ci.nsIFileOutputStream);
 
 	  fp.init(window, null, nsIFilePicker.modeSave);
 	  fp.defaultExtension = "txt";
@@ -1023,10 +1024,10 @@ classicthemerestorerjso.ctr = {
 	   
 	function loadFromFile() {
 
-	   const nsIFilePicker = Components.interfaces.nsIFilePicker;
-	   var fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
-	   var stream = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance(Components.interfaces.nsIFileInputStream);
-	   var streamIO = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
+	   const nsIFilePicker = Ci.nsIFilePicker;
+	   var fp = Cc["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
+	   var stream = Cc["@mozilla.org/network/file-input-stream;1"].createInstance(Ci.nsIFileInputStream);
+	   var streamIO = Cc["@mozilla.org/scriptableinputstream;1"].createInstance(Ci.nsIScriptableInputStream);
 
 	   fp.defaultExtension = "txt";
 	   fp.defaultString = "CTRpreferences.txt";
@@ -1082,7 +1083,7 @@ classicthemerestorerjso.ctr = {
 
 	  } catch(e) {
 		// Report errors to console
-		Components.utils.reportError(e);
+		Cu.reportError(e);
 	  }
 	}	
 
@@ -1097,10 +1098,10 @@ classicthemerestorerjso.ctr = {
 	 
 	function loadFromFile() {
 
-	   const nsIFilePicker = Components.interfaces.nsIFilePicker;
-	   var fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
-	   var stream = Components.classes["@mozilla.org/network/file-input-stream;1"].createInstance(Components.interfaces.nsIFileInputStream);
-	   var streamIO = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance(Components.interfaces.nsIScriptableInputStream);
+	   const nsIFilePicker = Ci.nsIFilePicker;
+	   var fp = Cc["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
+	   var stream = Cc["@mozilla.org/network/file-input-stream;1"].createInstance(Ci.nsIFileInputStream);
+	   var streamIO = Cc["@mozilla.org/scriptableinputstream;1"].createInstance(Ci.nsIScriptableInputStream);
 
 	   fp.defaultExtension = "json";
 	   fp.defaultString = "CTRpreferences.json";
@@ -1169,7 +1170,7 @@ classicthemerestorerjso.ctr = {
 
 	  } catch(e) {
 		// Report errors to console
-		Components.utils.reportError(e);
+		Cu.reportError(e);
 	  }
 
 	}
@@ -1178,9 +1179,9 @@ classicthemerestorerjso.ctr = {
 	  
 	function saveToFile(patterns) {
 
-	  const nsIFilePicker = Components.interfaces.nsIFilePicker;
-	  var fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
-	  var stream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(Components.interfaces.nsIFileOutputStream);
+	  const nsIFilePicker = Ci.nsIFilePicker;
+	  var fp = Cc["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
+	  var stream = Cc["@mozilla.org/network/file-output-stream;1"].createInstance(Ci.nsIFileOutputStream);
 
 	  fp.init(window, null, nsIFilePicker.modeSave);
 	  fp.defaultExtension = "json";
@@ -1221,3 +1222,8 @@ classicthemerestorerjso.ctr = {
   }
   
 };
+
+
+  // Make classicthemerestorerjso a global variable
+  global.classicthemerestorerjso = classicthemerestorerjso;
+}(this));

--- a/xpi/content/overlay.js
+++ b/xpi/content/overlay.js
@@ -1,19 +1,16 @@
 "use strict";
+(function(global) {
 /*
-	There are a few "timeouts" on this document. In almost all cases they are needed to
-	make sure a 'get' call looks only for items already in DOM. 
- 
-	Components.classes: Cc
-	Components.interfaces: Ci
-	Components.utils: Cu
+ There are a few "timeouts" on this document. In almost all cases they are needed to
+ make sure a 'get' call looks only for items already in DOM.
 */
 
-Cu.import("resource:///modules/CustomizableUI.jsm");
-Cu.import("resource://gre/modules/AddonManager.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
+var Cc = Components.classes, Ci = Components.interfaces, Cu = Components.utils;
 
-//Query nsIPrefBranch see: Bug 1125570 | Bug 1083561
-Services.prefs.QueryInterface(Ci.nsIPrefBranch);
+var {CustomizableUI} = Cu.import("resource:///modules/CustomizableUI.jsm", {});
+var {AddonManager} = Cu.import("resource://gre/modules/AddonManager.jsm", {});
+var {Services} = Cu.import("resource://gre/modules/Services.jsm", {});
+
 
 if (typeof classicthemerestorerjs == "undefined") {var classicthemerestorerjs = {};};
 if (!classicthemerestorerjs.ctr) {classicthemerestorerjs.ctr = {};};
@@ -1796,14 +1793,14 @@ classicthemerestorerjs.ctr = {
 				if (newURL=='') newURL='about:newtab';
 				
 				try{
-					Cu.import("resource:///modules/NewTabURL.jsm");
+					var {NewTabURL} = Cu.import("resource:///modules/NewTabURL.jsm", {});
 					NewTabURL.override(newURL);
 				} catch(e){}
 
 				
 			} else if (classicthemerestorerjs.ctr.appversion >= 41) {
 				try{
-				  Cu.import("resource:///modules/NewTabURL.jsm");
+				  var {NewTabURL} = Cu.import("resource:///modules/NewTabURL.jsm", {});
 				  NewTabURL.reset();
 				} catch(e){}
 			}
@@ -2450,12 +2447,12 @@ classicthemerestorerjs.ctr = {
 	// As result event listener fails to listen for "TabAttrModified" event.
 	// Waiting until dom content is loaded fixes this problem.
 	window.addEventListener("DOMContentLoaded", function _favIconinUrlbarCTR(){
-	  var mainWindow = window.QueryInterface(Components.interfaces.nsIInterfaceRequestor)
-                       .getInterface(Components.interfaces.nsIWebNavigation)
-                       .QueryInterface(Components.interfaces.nsIDocShellTreeItem)
+	  var mainWindow = window.QueryInterface(Ci.nsIInterfaceRequestor)
+                       .getInterface(Ci.nsIWebNavigation)
+                       .QueryInterface(Ci.nsIDocShellTreeItem)
                        .rootTreeItem
-                       .QueryInterface(Components.interfaces.nsIInterfaceRequestor)
-                       .getInterface(Components.interfaces.nsIDOMWindow);
+                       .QueryInterface(Ci.nsIInterfaceRequestor)
+                       .getInterface(Ci.nsIDOMWindow);
 					   
 	  mainWindow.gBrowser.tabContainer.addEventListener("TabAttrModified", faviconInUrlbar, false);
 	}, false);
@@ -2609,7 +2606,7 @@ classicthemerestorerjs.ctr = {
 
 	  try {
 		if (Services.prefs.getBranch("lightweightThemes.").getCharPref("selectedThemeID")=='firefox-devedition@mozilla.org') {
-		  Components.utils.import("resource://gre/modules/LightweightThemeManager.jsm");
+		 var {LightweightThemeManager} = Cu.import("resource://gre/modules/LightweightThemeManager.jsm", {});
 		  LightweightThemeManager.themeChanged(null);
 		  Services.prefs.getBranch("lightweightThemes.").deleteBranch("selectedThemeID");
 		}
@@ -4969,3 +4966,7 @@ classicthemerestorerjs.ctr = {
 };
 
 classicthemerestorerjs.ctr.init();
+
+  // Make classicthemerestorerjs a global variable
+  global.classicthemerestorerjs = classicthemerestorerjs;
+}(this));


### PR DESCRIPTION
Fix-up Name-spacing (addonManager, Services, NewTabURL) and other
imports are defined globally and accessible outside of Classic theme
restorer this change only makes them accessible with CTR.