### PR TITLE
Remove overlay on top of new tab page 42.0+

### DIFF
--- a/xpi/content/css/alt_newtabpage.css
+++ b/xpi/content/css/alt_newtabpage.css
@@ -122,6 +122,7 @@
 }
 
 /* remove overlay on top of new tab page */
+#newtab-customize-overlay,
 #newtab-window #newtab-customize-overlay {
   display: none !important;
 }


### PR DESCRIPTION
Changes made in Firefox 42.0+ has made the new tab page overlay appear, The above change resolves this.