### PR TITLE
Fixed: Hamburger menu text only showing outside the window.

### DIFF
--- a/xpi/content/css/mode_txtonly.css
+++ b/xpi/content/css/mode_txtonly.css
@@ -111,7 +111,7 @@
 	}
 	
 	toolbar .toolbarbutton-badge-stack {
-	  display: none !important;
+	  visibility: collapse !important;
 	}
 	
 }


### PR DESCRIPTION
If the preference `extensions.classicthemerestorer.nav_txt_ico` is set to `txtonly`
![sby8fb2jisbcvy822ji8wf](https://cloud.githubusercontent.com/assets/2867549/13135716/20ed8252-d65f-11e5-9494-92db74b703cf.jpg)

The menu is show outside of the browser window as shown in the image below
![sbdyf2ybrfihbsf8vy32br](https://cloud.githubusercontent.com/assets/2867549/13135676/becec342-d65e-11e5-8893-a45f5dfb8875.jpg)

The proposed change should work the same as display: none however not encounter this issue allowing the menu to show correctly, Now i have not tested this fix on OSX or Linux yet so it may not be the complete solution to this issue.

