### PR TITLE
Fixed bugs with ctraddon_bookmarks-menu-toolbar-button

### DIFF
--- a/xpi/content/overlay.xul
+++ b/xpi/content/overlay.xul
@@ -757,8 +757,7 @@
                    openInTabs="children"
                    oncommand="BookmarksEventHandler.onCommand(event, this.parentNode._placesView);"
                    onclick="BookmarksEventHandler.onClick(event, this.parentNode._placesView);"
-                   onpopupshowing="BookmarkingUI.onPopupShowing(event);
-                                   if (!this.parentNode._placesView) {new PlacesMenu(event, 'place:folder=BOOKMARKS_MENU');} classicthemerestorerjs.ctr.togglePersonalBarItem();"
+                   onpopupshowing="if (!this.parentNode._placesView) {new PlacesMenu(event, 'place:folder=BOOKMARKS_MENU');} classicthemerestorerjs.ctr.togglePersonalBarItem();"
                    tooltip="bhTooltip" popupsinherittooltip="true">
           <menuitem id="ctraddon_BMB_viewBookmarksSidebar"
                     type="checkbox"


### PR DESCRIPTION
When **ctraddon_bookmarks-menu-toolbar-button** is placed on the toolbar and the bookmarks button in the hamburger menu panel, The recently bookmarked menu spawned multiple instances of itself on menu popup showing even and did not populate correctly.

Also the button only worked when the hamburger menu panel had not been used, If the hamburger menu panel was used the bookmark menu drop-down no longer appeared but was shown inside the hamburger menu panel.

Bug show in youtube video https://www.youtube.com/watch?v=z_7X9njkV8o