### PR TITLE
Rename Puzzle Toolbars to Puzzle Bars

### DIFF
--- a/xpi/content/options.js
+++ b/xpi/content/options.js
@@ -214,7 +214,7 @@ classicthemerestorerjso.ctr = {
 	  }
 	});
 	
-	// Status4Evar, The Puzzle Piece, Puzzle Toolbars and The Addon Bar Restored
+	// Status4Evar, The Puzzle Piece, Puzzle Bars and The Addon Bar Restored
 	// override CTRs mov. status bar panel, so CTRs option gets disabled 
 	document.getElementById('ctraddon_pw_statusbar_s4e_info').style.visibility = 'collapse';
 	document.getElementById('ctraddon_pw_statusbar_tpp_info').style.visibility = 'collapse';

--- a/xpi/locale/cs/options.dtd
+++ b/xpi/locale/cs/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Přesunutelný stavový řádek">
 <!ENTITY Ctr_mstatusbars4e	"Stavový řádek je nastaven pomocí rozšíření 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"Stavový řádek je nastaven pomocí rozšíření 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"Stavový řádek je nastaven pomocí rozšíření 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"Stavový řádek je nastaven pomocí rozšíření 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"Stavový řádek je nastaven pomocí rozšíření 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Spojit tlačítka zastavit &amp; obnovit">
 <!ENTITY Ctr_stoprel1		"Důležité: umístěte tlačítko Obnovit za tlačítko Zastavit!">

--- a/xpi/locale/da/options.dtd
+++ b/xpi/locale/da/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Flytbare statuspanel">
 <!ENTITY Ctr_mstatusbars4e	"Statuslinje-panel styres af 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"Statuslinje-panel styres af 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"Statuslinje-panel styres af 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"Statuslinje-panel styres af 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"Statuslinje-panel styres af 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Stop &amp; genindlæs: kombinér knapper på værktøjslinje">
 <!ENTITY Ctr_stoprel1		"Vigtigt: placér genindlæs efter stop!">

--- a/xpi/locale/de/options.dtd
+++ b/xpi/locale/de/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Statusbereich: sichtbar und verschiebbar">
 <!ENTITY Ctr_mstatusbars4e	"Statusbereich wird von 'Status-4-Evar' kontrolliert">
 <!ENTITY Ctr_mstatusbartpp	"Statusbereich wird von 'ThePuzzlePiece' kontrolliert">
-<!ENTITY Ctr_mstatusbarpzt	"Statusbereich wird von 'Puzzle Toolbars' kontrolliert">
+<!ENTITY Ctr_mstatusbarpzt	"Statusbereich wird von 'Puzzle Bars' kontrolliert">
 <!ENTITY Ctr_mstatusbarabr	"Statusbereich wird von 'The Addon Bar (Restored)' kontrolliert">
 <!ENTITY Ctr_combrelstop	"'Stopp' &amp; 'Neu laden': Leistenschaltflächen kombinieren">
 <!ENTITY Ctr_stoprel1		"Reihenfolge beachten: 'Stopp' muss vor 'Neu laden' sein!">

--- a/xpi/locale/dsb/options.dtd
+++ b/xpi/locale/dsb/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Pśesuwajobny wobcerk statusoweje rědki">
 <!ENTITY Ctr_mstatusbars4e	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Tłocaška Stoj a Znowego kombiněrowaś">
 <!ENTITY Ctr_stoprel1		"Wažny: Tłocašk Znowego za tłocaškom Stoj placěrowaś!">

--- a/xpi/locale/el/options.dtd
+++ b/xpi/locale/el/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Μετακινήσιμο πινακίδιο γραμμής κατάστασης">
 <!ENTITY Ctr_mstatusbars4e	"Το πινακίδιο γραμμής κατάστασης ελέγχεται από την επέκταση «Status-4-Evar»">
 <!ENTITY Ctr_mstatusbartpp	"Το πινακίδιο γραμμής κατάστασης ελέγχεται από την επέκταση «ThePuzzlePiece»">
-<!ENTITY Ctr_mstatusbarpzt	"Το πινακίδιο γραμμής κατάστασης ελέγχεται από την επέκταση «Puzzle Toolbars»">
+<!ENTITY Ctr_mstatusbarpzt	"Το πινακίδιο γραμμής κατάστασης ελέγχεται από την επέκταση «Puzzle Bars»">
 <!ENTITY Ctr_mstatusbarabr	"Το πινακίδιο γραμμής κατάστασης ελέγχεται από την επέκταση «The Addon Bar (Restored)»">
 <!ENTITY Ctr_combrelstop	"Κουμπιά «Διακοπή» &amp; «Ανανέωση»: συνδυασμός κουμπιών στην εργαλειοθήκη">
 <!ENTITY Ctr_stoprel1		"Σημαντικό: τοποθετήστε το κουμπί «Ανανέωση» μετά από το κουμπί «Διακοπή»!">

--- a/xpi/locale/en-US/options.dtd
+++ b/xpi/locale/en-US/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Movable status panel">
 <!ENTITY Ctr_mstatusbars4e	"Status-bar panel is controlled by 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"Status-bar panel is controlled by 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"Status-bar panel is controlled by 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"Status-bar panel is controlled by 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"Status-bar panel is controlled by 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Stop &amp; reload: combine buttons on toolbar">
 <!ENTITY Ctr_stoprel1		"Important: position reload button after stop button!">

--- a/xpi/locale/es/options.dtd
+++ b/xpi/locale/es/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Mostrar panel móvil de la antigua barra de estado">
 <!ENTITY Ctr_mstatusbars4e	"El panel de barra de estado está controlado por 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"El panel de barra de estado está controlado por 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"El panel de barra de estado está controlado por 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"El panel de barra de estado está controlado por 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"El panel de barra de estado está controlado por 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Combinar botones Parar-Recargar">
 <!ENTITY Ctr_stoprel1		"Importante: ¡Sitúe el botón Recargar después del botón Parar!">

--- a/xpi/locale/et/options.dtd
+++ b/xpi/locale/et/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Liigutatav olekupaneel">
 <!ENTITY Ctr_mstatusbars4e	"Olekuriba paneeli kontrollib 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"Olekuriba paneeli kontrollib 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"Olekuriba paneeli kontrollib 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"Olekuriba paneeli kontrollib 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"Olekuriba paneeli kontrollib 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Peatamine &amp; uuestilaadimine: ühenda nupud tööriistaribal">
 <!ENTITY Ctr_stoprel1		"Tähtis: paiguta uuestilaadimise nupp peatamise nupu järele!">

--- a/xpi/locale/fr/options.dtd
+++ b/xpi/locale/fr/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Rendre mobile le panneau de la barre d'état">
 <!ENTITY Ctr_mstatusbars4e	"Le panneau de la barre d'état est contrôlé par « Status-4-Evar ».">
 <!ENTITY Ctr_mstatusbartpp	"Le panneau de la barre d'état est contrôlé par « The Puzzle Piece ».">
-<!ENTITY Ctr_mstatusbarpzt	"Le panneau de la barre d'état est contrôlé par « Puzzle Toolbars ».">
+<!ENTITY Ctr_mstatusbarpzt	"Le panneau de la barre d'état est contrôlé par « Puzzle Bars ».">
 <!ENTITY Ctr_mstatusbarabr	"Le panneau de la barre d'état est contrôlé par « The Addon Bar (Restored) ».">
 <!ENTITY Ctr_combrelstop 	"« Arrêter » &amp; « Actualiser » : combiner les boutons sur la barre d'outils">
 <!ENTITY Ctr_stoprel1		"Important : positionner le bouton « Actualiser » après le bouton « Arrêter » !">

--- a/xpi/locale/hsb/options.dtd
+++ b/xpi/locale/hsb/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Přesuwajomny wobłuk statusoweje lajsty">
 <!ENTITY Ctr_mstatusbars4e	"Statusowy wobłuk seo přez 'Status-4-Evar' kontroluje">
 <!ENTITY Ctr_mstatusbartpp	"Statusowy wobłuk so přez 'ThePuzzlePiece' kontroluje">
-<!ENTITY Ctr_mstatusbarpzt	"Statusowy wobłuk so přez 'Puzzle Toolbars' kontroluje">
+<!ENTITY Ctr_mstatusbarpzt	"Statusowy wobłuk so přez 'Puzzle Bars' kontroluje">
 <!ENTITY Ctr_mstatusbarabr	"Statusowy wobłuk so přez 'The Addon Bar (Restored)' komtroluje">
 <!ENTITY Ctr_combrelstop	"Tłóčatce Stój a Znowa kombinować">
 <!ENTITY Ctr_stoprel1		"Wažny: Tłóčatko Znowa za tłóčatkom Stój zaměstnić!">

--- a/xpi/locale/it/options.dtd
+++ b/xpi/locale/it/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Barra di stato mobile">
 <!ENTITY Ctr_mstatusbars4e	"La barra di stato è gestita da 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"La barra di stato è gestita da 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"La barra di stato è gestita da 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"La barra di stato è gestita da 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"La barra di stato è gestita da 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Unisci i pulsanti Stop e Ricarica">
 <!ENTITY Ctr_stoprel1		"Importante: disporre il pulsante Ricarica a destra del pulsante Stop!">

--- a/xpi/locale/ja/options.dtd
+++ b/xpi/locale/ja/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"ステータスバーパネルを移動可能にする">
 <!ENTITY Ctr_mstatusbars4e	"ステータスバーパネルは Status-4-Evar で制御されます。">
 <!ENTITY Ctr_mstatusbartpp	"ステータスバーパネルは ThePuzzlePiece で制御されます。">
-<!ENTITY Ctr_mstatusbarpzt	"ステータスバーパネルは Puzzle Toolbars で制御されます。">
+<!ENTITY Ctr_mstatusbarpzt	"ステータスバーパネルは Puzzle Bars で制御されます。">
 <!ENTITY Ctr_mstatusbarabr	"ステータスバーパネルは The Addon Bar (Restored) で制御されます。">
 <!ENTITY Ctr_combrelstop	"中止ボタンと再読み込みボタンを組み合わせる">
 <!ENTITY Ctr_stoprel1		"重要：停止ボタンの後ろに再読み込みボタンを設置します">

--- a/xpi/locale/pl/options.dtd
+++ b/xpi/locale/pl/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Ruchomy panel paska statusu">
 <!ENTITY Ctr_mstatusbars4e	"Panel paska statusu jest kontrolowany przez 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"Panel paska statusu jest kontrolowany przez 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"Panel paska statusu jest kontrolowany przez 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"Panel paska statusu jest kontrolowany przez 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"Panel paska statusu jest kontrolowany przez 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Połącz przyciski zatrzymania i odświeżania">
 <!ENTITY Ctr_stoprel1		"Ważne: umieść przycisk odświeżania za przyciskiem zatrzymania!">

--- a/xpi/locale/pt-BR/options.dtd
+++ b/xpi/locale/pt-BR/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Painel da Barra de Status Móvel">
 <!ENTITY Ctr_mstatusbars4e	"O Painel da Barra de Status é Controlado Pelo 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"O Painel da Barra de Status é Controlado Pelo 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"O Painel da Barra de Status é Controlado Pelo 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"O Painel da Barra de Status é Controlado Pelo 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"O Painel da Barra de Status é Controlado Pelo 'The Addon Bar (Restaurado)'">
 <!ENTITY Ctr_combrelstop	"Combinar os Botões Parar e Recarregar">
 <!ENTITY Ctr_stoprel1		"Barra de Ferramentas: Colocar o Botão Recarregar Depois do Botão Parar!">

--- a/xpi/locale/ru/options.dtd
+++ b/xpi/locale/ru/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Подвижная строка состояния">
 <!ENTITY Ctr_mstatusbars4e	"Панель статуса контролируется 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"Панель статуса контролируется 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"Панель статуса контролируется 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"Панель статуса контролируется 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"Панель статуса контролируется 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Совместить кнопки «Остановить» и «Перезагрузить»">
 <!ENTITY Ctr_stoprel1		"Кнопка остановки меняется на панели инструментов на кнопку перезагрузки после остановки!">

--- a/xpi/locale/sl/options.dtd
+++ b/xpi/locale/sl/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Premakljivo podokno stanja">
 <!ENTITY Ctr_mstatusbars4e	"Podokno stanja nadzira 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"Podokno stanja nadzira 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"Podokno stanja nadzira 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"Podokno stanja nadzira 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"Podokno stanja nadzira 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Ustavi in Ponovno naloži: združi gumba na orodni vrstici">
 <!ENTITY Ctr_stoprel1		"Pomembno: gumb Ponovno naloži vstavite za gumb Ustavi!">

--- a/xpi/locale/tr/options.dtd
+++ b/xpi/locale/tr/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Hareketli durum çubuğu paneli">
 <!ENTITY Ctr_mstatusbars4e	"Durum çubuğu paneli 'Status-4-Evar' tarafından kontrol edilir">
 <!ENTITY Ctr_mstatusbartpp	"Durum çubuğu paneli 'ThePuzzlePiece' tarafından kontrol edilir">
-<!ENTITY Ctr_mstatusbarpzt	"Durum çubuğu paneli 'Puzzle Toolbars' tarafından kontrol edilir">
+<!ENTITY Ctr_mstatusbarpzt	"Durum çubuğu paneli 'Puzzle Bars' tarafından kontrol edilir">
 <!ENTITY Ctr_mstatusbarabr	"Durum çubuğu paneli 'The Addon Bar (Restored)' tarafından kontrol edilir">
 <!ENTITY Ctr_combrelstop	"Dur &amp; yenile butonlarını birleştir">
 <!ENTITY Ctr_stoprel1		"Önemli: yenile butonunu dur butonundan sonra yerleştir!">

--- a/xpi/locale/uk/options.dtd
+++ b/xpi/locale/uk/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"Рухомий рядок стану">
 <!ENTITY Ctr_mstatusbars4e	"Панель статусу контролюється додатком «Status-4-Evar»">
 <!ENTITY Ctr_mstatusbartpp	"Панель статусу контролюється додатком «ThePuzzlePiece»">
-<!ENTITY Ctr_mstatusbarpzt	"Панель статусу контролюється додатком «Puzzle Toolbars»">
+<!ENTITY Ctr_mstatusbarpzt	"Панель статусу контролюється додатком «Puzzle Bars»">
 <!ENTITY Ctr_mstatusbarabr	"Панель статусу контролюється додатком «The Addon Bar (Restored)»">
 <!ENTITY Ctr_combrelstop	"Об’єднати кнопки «Зупинити» та «Перезавантажити»">
 <!ENTITY Ctr_stoprel1		"Важливо: з’являється кнопка «Перезавантаження» на місці кнопки «Зупинити»!">

--- a/xpi/locale/zh-CN/options.dtd
+++ b/xpi/locale/zh-CN/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"使状态栏面板可以移动">
 <!ENTITY Ctr_mstatusbars4e	"状态栏面板由“Status-4-Evar”所控制">
 <!ENTITY Ctr_mstatusbartpp	"状态栏面板由“ThePuzzlePiece”所控制">
-<!ENTITY Ctr_mstatusbarpzt	"状态栏面板由“Puzzle Toolbars”所控制">
+<!ENTITY Ctr_mstatusbarpzt	"状态栏面板由“Puzzle Bars”所控制">
 <!ENTITY Ctr_mstatusbarabr	"状态栏面板由“The Addon Bar (Restored)”所控制">
 <!ENTITY Ctr_combrelstop	"在工具栏上合并停止和重新载入按钮">
 <!ENTITY Ctr_stoprel1		"重要: 将重新载入按钮放在停止按钮后面!">

--- a/xpi/locale/zh-TW/options.dtd
+++ b/xpi/locale/zh-TW/options.dtd
@@ -133,7 +133,7 @@
 <!ENTITY Ctr_mstatusbar		"使狀態列可移動">
 <!ENTITY Ctr_mstatusbars4e	"狀態列由 Status-4-Evar 控制">
 <!ENTITY Ctr_mstatusbartpp	"狀態列由 The Puzzle Piece 控制">
-<!ENTITY Ctr_mstatusbarpzt	"狀態列由 Puzzle Toolbars 控制">
+<!ENTITY Ctr_mstatusbarpzt	"狀態列由 Puzzle Bars 控制">
 <!ENTITY Ctr_mstatusbarabr	"狀態列由 The Addon Bar (Restored) 控制">
 <!ENTITY Ctr_combrelstop	"合併停止與重新載入按鈕">
 <!ENTITY Ctr_stoprel1		"工具列: 將重新載入按鈕放在停止按鈕之後!">


### PR DESCRIPTION
I just noticed CTR still mentions "Puzzle Toolbars" everywhere. It's probably less confusing for everyone if it says "Puzzle Bars".

("Puzzle Toolbars" was its name for only one or two versions; I had to rename it shortly after release because it was being confused with one of those unwanted toolbar-adware/malware/greyware things, which of course it isn't.)

If you could also update #117 accordingly, I would appreciate it. BTW, bonus points for adding links to the corresponding add-on homepages in that post, so that users can go directly to them instead of having to search for them, and in this case they would fail to find it for instance. Just a tiny suggestion of course. :)