### PR TITLE
Addon name was reverted from 'Puzzle Bars' back to 'Puzzle Toolbars'

### DIFF
--- a/xpi/locale/dsb/options.dtd
+++ b/xpi/locale/dsb/options.dtd
@@ -138,7 +138,7 @@
 <!ENTITY Ctr_mstatusbar		"Pśesuwajobny wobcerk statusoweje rědki">
 <!ENTITY Ctr_mstatusbars4e	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'Status-4-Evar'">
 <!ENTITY Ctr_mstatusbartpp	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'ThePuzzlePiece'">
-<!ENTITY Ctr_mstatusbarpzt	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'Puzzle Toolbars'">
+<!ENTITY Ctr_mstatusbarpzt	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'Puzzle Bars'">
 <!ENTITY Ctr_mstatusbarabr	"Wobcerk statusoweje rědki kontrolěrujo se pśez 'The Addon Bar (Restored)'">
 <!ENTITY Ctr_combrelstop	"Tłocaška Stoj a Znowego kombiněrowaś">
 <!ENTITY Ctr_stoprel1		"Wažny: Tłocašk Znowego za tłocaškom Stoj placěrowaś!">


### PR DESCRIPTION
@Aris-t2  This change reverts the addon name back to the newly changed value.
Not sure if this was meant to change, So just ignore this if it was correct.