### PR TITLE
Option to hide page title in address bar popup

### DIFF
--- a/xpi/content/css/alt_autocompl_title.css
+++ b/xpi/content/css/alt_autocompl_title.css
@@ -1,0 +1,11 @@
+@namespace url(http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul);
+
+@-moz-document url(chrome://browser/content/browser.xul) {
+
+  panel[type="autocomplete-richlistbox"] .autocomplete-richlistitem:not([collapse="true"]) .ac-title,
+  #PopupAutoCompleteRichResult[autocompleteinput="urlbar"] .autocomplete-richlistitem:not([collapse="true"]) .ac-title,
+  panel[type="autocomplete-richlistbox"] .autocomplete-richlistitem:not([collapse="true"]) .ac-separator,
+  #PopupAutoCompleteRichResult[autocompleteinput="urlbar"] .autocomplete-richlistitem:not([collapse="true"]) .ac-separator {
+    display: none !important;
+  }
+}

--- a/xpi/content/options.js
+++ b/xpi/content/options.js
@@ -401,6 +401,7 @@ classicthemerestorerjso.ctr = {
 	if (this.appversion < 48) {
 	  document.getElementById('ctraddon_pw_altautocompl').style.visibility = 'collapse';
 	  document.getElementById('ctraddon_pw_autocompl_it').style.visibility = 'collapse';
+	  document.getElementById('ctraddon_pw_autocompl_title').style.visibility = 'collapse';
 	  document.getElementById('ctraddon_pw_autocompl_rhl').style.visibility = 'collapse';
 	  document.getElementById('ctraddon_pw_anewtaburlpcb').style.visibility = 'collapse';
 	  document.getElementById('ctraddon_pw_anewtaburlpurlbox').style.visibility = 'collapse';
@@ -898,7 +899,7 @@ classicthemerestorerjso.ctr = {
 	else which=true;
 	
     document.getElementById('ctraddon_pw_autocompl_it').disabled = which;
-
+    document.getElementById('ctraddon_pw_autocompl_title').disabled = which;
   },
   
   ctrpwAltAutocomplete: function(which) {

--- a/xpi/content/options.xul
+++ b/xpi/content/options.xul
@@ -131,6 +131,7 @@
 		<preference id="ctraddon_hideurlzoom"	name="extensions.classicthemerestorer.hideurlzoom"	type="bool"		instantApply="true"/>
 		<preference id="ctraddon_altautocompl"	name="extensions.classicthemerestorer.altautocompl"	type="bool"		instantApply="true"/>
 		<preference id="ctraddon_autocompl_it"	name="extensions.classicthemerestorer.autocompl_it"	type="bool"		instantApply="true"/>
+		<preference id="ctraddon_autocompl_title"	name="extensions.classicthemerestorer.autocompl_title"	type="bool"		instantApply="true"/>
 		<preference id="ctraddon_autocompl_it2"	name="extensions.classicthemerestorer.autocompl_it2" type="bool"	instantApply="true"/>
 		<preference id="ctraddon_autocompl_hlb"	name="extensions.classicthemerestorer.autocompl_hlb" type="bool"	instantApply="true"/>
 		<preference id="ctraddon_autocompl_hlu"	name="extensions.classicthemerestorer.autocompl_hlu" type="bool"	instantApply="true"/>
@@ -1194,6 +1195,7 @@
 		<checkbox label="&Ctr_autocompl_rhl;" preference="ctraddon_autocompl_rhl" id="ctraddon_pw_autocompl_rhl" class="ctraddon_new_in_v48"/>
 		<checkbox label="&Ctr_lbsugresi;" preference="ctraddon_urlresults" id="ctraddon_pw_urlresults" oncommand="if(this.checked) {classicthemerestorerjso.ctr.ctrpwAutoCompleteHeight(true);} else {classicthemerestorerjso.ctr.ctrpwAutoCompleteHeight(false);}"/>
 		<checkbox label="&Ctr_autocompl_it;" preference="ctraddon_autocompl_it" id="ctraddon_pw_autocompl_it" class="ctraddon_new_in_v48"/>
+		<checkbox label="&Ctr_autocompl_title;" preference="ctraddon_autocompl_title" id="ctraddon_pw_autocompl_title" class="ctraddon_new_in_v48"/>
 		<hbox align="center" id="ctraddon_pw_cresultshbox">
 		  <checkbox label="&Ctr_cresultshcb;" preference="ctraddon_cresultshcb" id="ctraddon_pw_cresultshcb" class="ctraddon_new_in_v48" oncommand="classicthemerestorerjso.ctr.needsBrowserRestart()"/>
 		  <textbox size="4" maxlength="4" preference="ctraddon_cresultsh" type="number" min="0" max="9999" id="ctraddon_pw_cresultsh"/>

--- a/xpi/content/overlay.js
+++ b/xpi/content/overlay.js
@@ -1162,7 +1162,7 @@ classicthemerestorerjs.ctr = {
 			  else classicthemerestorerjs.ctr.loadUnloadCSS("altautocompl",false);
 		  break;
 		  
-		  case "urlresults": case "autocompl_it":
+		  case "urlresults": case "autocompl_it": case "autocompl_title":
 			if (branch.getBoolPref("urlresults")) {
 			  classicthemerestorerjs.ctr.loadUnloadCSS("urlresults",true);
 			  
@@ -1182,6 +1182,13 @@ classicthemerestorerjs.ctr = {
 					&& classicthemerestorerjs.ctr.appversion < 50)
 						classicthemerestorerjs.ctr.loadUnloadCSS("autocompl_it",true);
 			  else classicthemerestorerjs.ctr.loadUnloadCSS("autocompl_it",false);
+
+      if (branch.getBoolPref("autocompl_title") && branch.getBoolPref("urlresults")
+				&& classicthemerestorerjs.ctr.appversion >= 48
+					&& classicthemerestorerjs.ctr.appversion < 50
+						&& branch.getBoolPref("altautocompl")==false)
+							classicthemerestorerjs.ctr.loadUnloadCSS("autocompl_title",true);
+				else classicthemerestorerjs.ctr.loadUnloadCSS("autocompl_title",false);
 		  break;
 		  
 		  case "cresultshcb":  
@@ -4115,6 +4122,7 @@ classicthemerestorerjs.ctr = {
 		case "autocompl_hli": 		manageCSS("alt_autocompl_hl_i.css");	break;
 		case "autocompl_hln": 		manageCSS("alt_autocompl_hl_n.css");	break;
 		case "autocompl_sep": 		manageCSS("alt_autocompl_sep.css");		break;
+		case "autocompl_title": 		manageCSS("alt_autocompl_title.css");		break;
 		case "autocompl_rhl": 		manageCSS("alt_autocompl_rhl.css");		break;
 		case "locsearchbw10": 		manageCSS("locationsearchbarw10.css");	break;
 		case "combrelstop":			manageCSS("combrelstop.css");			break;

--- a/xpi/defaults/preferences/options.js
+++ b/xpi/defaults/preferences/options.js
@@ -144,6 +144,7 @@ pref("extensions.classicthemerestorer.autocompl_hli",false);
 pref("extensions.classicthemerestorer.autocompl_hln",false);
 pref("extensions.classicthemerestorer.autocompl_sep",false);
 pref("extensions.classicthemerestorer.autocompl_rhl",false);
+pref("extensions.classicthemerestorer.autocompl_title",false);
 
 pref("extensions.classicthemerestorer.ib_nohovcolor",false);
 pref("extensions.classicthemerestorer.ib_graycolor",false);

--- a/xpi/locale/de/options.dtd
+++ b/xpi/locale/de/options.dtd
@@ -283,6 +283,7 @@
 <!ENTITY Ctr_autocompl_hl	"Hervorhebung von Texttreffern">
 <!ENTITY Ctr_autocompl_rhl	"Blaue 'Aero'-Farben für hervorgehobene Ergebnisse">
 <!ENTITY Ctr_autocompl_sep	"Trennlinie zwischen den Ergebnissen anzeigen">
+<!ENTITY Ctr_autocompl_title	"Seiten-Titel verbergen">
 <!ENTITY Ctr_urlbar_uc		"'Vereinigte Autovervollständigung' deaktivieren">
 <!ENTITY Ctr_lbsugresi		"Höhenlimit deaktivieren">
 <!ENTITY Ctr_cresultshcb	"Eigenes Höhenlimit setzen: ">

--- a/xpi/locale/en-US/options.dtd
+++ b/xpi/locale/en-US/options.dtd
@@ -283,6 +283,7 @@
 <!ENTITY Ctr_autocompl_hl	"Highlighting of text hits">
 <!ENTITY Ctr_autocompl_rhl	"Aero colors for highlighted results">
 <!ENTITY Ctr_autocompl_sep	"Show separator between results">
+<!ENTITY Ctr_autocompl_title	"Hide page title">
 <!ENTITY Ctr_urlbar_uc		"Disable 'unified autocomplete' feature">
 <!ENTITY Ctr_lbsugresi		"Disable height limit">
 <!ENTITY Ctr_cresultshcb	"Custom height limit: ">


### PR DESCRIPTION
This adds an option to hide the page title (and the following separator) in
the richresult popup results of the address bar. This currently only
works with the non-alternative address bar popup.
Still needs localization for languages other than english and german.